### PR TITLE
Avoid require(smartcard) crashes if service is not started

### DIFF
--- a/src/Devices.js
+++ b/src/Devices.js
@@ -5,9 +5,6 @@ import pcsclite from 'pcsclite';
 import Device from './Device';
 
 
-// const pcsc = pcsclite();
-
-
 class Devices extends EventEmitter {
     constructor() {
         super();

--- a/src/Devices.js
+++ b/src/Devices.js
@@ -5,7 +5,7 @@ import pcsclite from 'pcsclite';
 import Device from './Device';
 
 
-const pcsc = pcsclite();
+// const pcsc = pcsclite();
 
 
 class Devices extends EventEmitter {


### PR DESCRIPTION
Just importing smartcard lib make app crash if pcscd service is not started. I'm working on a project where multiple card readers can be configured (factory), some are pcscd compliant some are not, so it's not useful to install this service.