### PR TITLE
Fix: emit reader-attached events for pre-existing readers on start()

### DIFF
--- a/src/reader_monitor.cpp
+++ b/src/reader_monitor.cpp
@@ -136,6 +136,14 @@ void ReaderMonitor::MonitorLoop() {
     // Get initial reader list
     UpdateReaderList();
 
+    // Emit reader-attached events for all pre-existing readers (Issue #30)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& reader : readers_) {
+            EmitEvent("reader-attached", reader.name, reader.lastState, reader.atr);
+        }
+    }
+
     // Build initial states array with PnP notification
     std::vector<SCARD_READERSTATE> states;
     std::vector<std::string> readerNames;


### PR DESCRIPTION
## Summary
- Fixes #30: ReaderMonitor now emits `reader-attached` events for already-connected readers when `start()` is called
- Adds test to verify pre-existing reader detection works correctly

## Changes
- **src/reader_monitor.cpp**: After `UpdateReaderList()` in `MonitorLoop()`, emit `reader-attached` events for all initially detected readers with their current state and ATR
- **test/test.js**: Added test that verifies `reader-attached` events are emitted for pre-existing readers on startup

## Test plan
- [x] New test confirms pre-existing readers emit `reader-attached` on `start()`
- [x] Existing tests continue to pass
- [x] Cards already inserted in pre-existing readers are now detected (via `SCARD_STATE_PRESENT` check in `_handleReaderAttached`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)