### PR TITLE
Add mocking framework for CI testing without hardware

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
         "install": "node-gyp rebuild",
         "build": "node-gyp rebuild",
         "rebuild": "node-gyp rebuild",
-        "test": "node test/test.js"
+        "test": "node test/test.js && node test/unit.js",
+        "test:unit": "node test/unit.js",
+        "test:integration": "node test/test.js"
     },
     "files": [
         "lib/",

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,0 +1,460 @@
+// @ts-check
+'use strict';
+
+/**
+ * Mock PC/SC implementation for testing without hardware
+ */
+
+/**
+ * @typedef {Object} MockReaderConfig
+ * @property {string} name - Reader name
+ * @property {boolean} [hasCard] - Whether a card is present
+ * @property {Buffer} [atr] - Card ATR if present
+ * @property {number} [protocol] - Card protocol (1=T0, 2=T1)
+ */
+
+/**
+ * @typedef {Object} MockCardResponse
+ * @property {Buffer|number[]} command - APDU command to match
+ * @property {Buffer|number[]} response - Response to return
+ */
+
+class MockCard {
+    /**
+     * @param {number} protocol
+     * @param {Buffer} atr
+     * @param {MockCardResponse[]} responses
+     */
+    constructor(protocol, atr, responses = []) {
+        this.protocol = protocol;
+        this._atr = atr;
+        this._responses = responses;
+        this._connected = true;
+    }
+
+    get connected() {
+        return this._connected;
+    }
+
+    get atr() {
+        return this._connected ? this._atr : null;
+    }
+
+    /**
+     * @param {Buffer|number[]} command
+     * @returns {Promise<Buffer>}
+     */
+    async transmit(command) {
+        if (!this._connected) {
+            throw new Error('Card is not connected');
+        }
+
+        const cmdBuffer = Buffer.isBuffer(command) ? command : Buffer.from(command);
+
+        // Find matching response
+        for (const { command: cmd, response } of this._responses) {
+            const cmdMatch = Buffer.isBuffer(cmd) ? cmd : Buffer.from(cmd);
+            if (cmdBuffer.equals(cmdMatch)) {
+                return Buffer.isBuffer(response) ? response : Buffer.from(response);
+            }
+        }
+
+        // Default: return success status (90 00)
+        return Buffer.from([0x90, 0x00]);
+    }
+
+    /**
+     * @param {number} code
+     * @param {Buffer} [data]
+     * @returns {Promise<Buffer>}
+     */
+    async control(code, data) {
+        if (!this._connected) {
+            throw new Error('Card is not connected');
+        }
+        return Buffer.from([0x90, 0x00]);
+    }
+
+    getStatus() {
+        if (!this._connected) {
+            throw new Error('Card is not connected');
+        }
+        return {
+            state: 0x34, // SCARD_STATE_PRESENT | SCARD_STATE_POWERED | SCARD_STATE_SPECIFIC
+            protocol: this.protocol,
+            atr: this._atr,
+        };
+    }
+
+    disconnect() {
+        this._connected = false;
+    }
+
+    /**
+     * @param {number} [shareMode]
+     * @param {number} [protocol]
+     * @param {number} [init]
+     */
+    reconnect(shareMode, protocol, init) {
+        this._connected = true;
+        return this.protocol;
+    }
+}
+
+class MockReader {
+    /**
+     * @param {string} name
+     * @param {MockCard|null} card
+     */
+    constructor(name, card = null) {
+        this.name = name;
+        this._card = card;
+        this._state = card ? 0x122 : 0x12; // PRESENT or EMPTY
+    }
+
+    get state() {
+        return this._state;
+    }
+
+    get atr() {
+        return this._card ? this._card.atr : null;
+    }
+
+    /**
+     * @param {number} [shareMode]
+     * @param {number} [protocol]
+     * @returns {Promise<MockCard>}
+     */
+    async connect(shareMode, protocol) {
+        if (!this._card) {
+            throw new Error('No card in reader');
+        }
+        return this._card;
+    }
+
+    /**
+     * Insert a card into the reader
+     * @param {MockCard} card
+     */
+    insertCard(card) {
+        this._card = card;
+        this._state = 0x122;
+    }
+
+    /**
+     * Remove the card from the reader
+     */
+    removeCard() {
+        if (this._card) {
+            this._card.disconnect();
+        }
+        this._card = null;
+        this._state = 0x12;
+    }
+}
+
+class MockContext {
+    constructor() {
+        /** @type {MockReader[]} */
+        this._readers = [];
+        this._valid = true;
+    }
+
+    get isValid() {
+        return this._valid;
+    }
+
+    /**
+     * @returns {MockReader[]}
+     */
+    listReaders() {
+        if (!this._valid) {
+            throw new Error('Context is not valid');
+        }
+        return [...this._readers];
+    }
+
+    /**
+     * @param {MockReader[]} [readers]
+     * @param {number} [timeout]
+     * @returns {Promise<Object[]|null>}
+     */
+    async waitForChange(readers, timeout) {
+        // In mock, just return empty (no changes)
+        return [];
+    }
+
+    cancel() {
+        // No-op in mock
+    }
+
+    close() {
+        this._valid = false;
+    }
+
+    /**
+     * Add a reader to the mock context
+     * @param {MockReader} reader
+     */
+    addReader(reader) {
+        this._readers.push(reader);
+    }
+
+    /**
+     * Remove a reader from the mock context
+     * @param {string} name
+     */
+    removeReader(name) {
+        this._readers = this._readers.filter(r => r.name !== name);
+    }
+}
+
+class MockReaderMonitor {
+    constructor() {
+        this._running = false;
+        this._callback = null;
+        /** @type {MockReader[]} */
+        this._readers = [];
+    }
+
+    get isRunning() {
+        return this._running;
+    }
+
+    /**
+     * @param {Function} callback
+     */
+    start(callback) {
+        if (this._running) {
+            throw new Error('Monitor is already running');
+        }
+        this._callback = callback;
+        this._running = true;
+
+        // Emit events for existing readers
+        for (const reader of this._readers) {
+            this._emitEvent('reader-attached', reader.name, reader.state, reader.atr);
+        }
+    }
+
+    stop() {
+        this._running = false;
+        this._callback = null;
+    }
+
+    /**
+     * @param {string} type
+     * @param {string} readerName
+     * @param {number} state
+     * @param {Buffer|null} atr
+     */
+    _emitEvent(type, readerName, state, atr) {
+        if (this._callback) {
+            this._callback({ type, reader: readerName, state, atr });
+        }
+    }
+
+    /**
+     * Simulate attaching a reader
+     * @param {MockReader} reader
+     */
+    attachReader(reader) {
+        this._readers.push(reader);
+        if (this._running) {
+            this._emitEvent('reader-attached', reader.name, reader.state, reader.atr);
+        }
+    }
+
+    /**
+     * Simulate detaching a reader
+     * @param {string} name
+     */
+    detachReader(name) {
+        this._readers = this._readers.filter(r => r.name !== name);
+        if (this._running) {
+            this._emitEvent('reader-detached', name, 0, null);
+        }
+    }
+
+    /**
+     * Simulate inserting a card
+     * @param {string} readerName
+     * @param {MockCard} card
+     */
+    insertCard(readerName, card) {
+        const reader = this._readers.find(r => r.name === readerName);
+        if (reader) {
+            reader.insertCard(card);
+            if (this._running) {
+                this._emitEvent('card-inserted', readerName, reader.state, card.atr);
+            }
+        }
+    }
+
+    /**
+     * Simulate removing a card
+     * @param {string} readerName
+     */
+    removeCard(readerName) {
+        const reader = this._readers.find(r => r.name === readerName);
+        if (reader) {
+            reader.removeCard();
+            if (this._running) {
+                this._emitEvent('card-removed', readerName, reader.state, null);
+            }
+        }
+    }
+}
+
+/**
+ * Create a mock-enabled Devices class
+ * @param {Object} mockAddon - Mock addon with Context and ReaderMonitor
+ * @returns {typeof import('../lib/devices').Devices}
+ */
+function createMockDevices(mockAddon) {
+    const EventEmitter = require('events');
+
+    const { Context, ReaderMonitor } = mockAddon;
+    const SCARD_STATE_PRESENT = 0x20;
+    const SCARD_SHARE_SHARED = 2;
+    const SCARD_PROTOCOL_T0 = 1;
+    const SCARD_PROTOCOL_T1 = 2;
+
+    class MockDevices extends EventEmitter {
+        constructor() {
+            super();
+            this._monitor = null;
+            this._context = null;
+            this._running = false;
+            this._readers = new Map();
+            this._eventQueue = Promise.resolve();
+        }
+
+        start() {
+            if (this._running) return;
+
+            try {
+                this._context = new Context();
+                this._monitor = new ReaderMonitor();
+                this._running = true;
+                this._monitor.start((event) => this._handleEvent(event));
+            } catch (err) {
+                this.emit('error', err);
+            }
+        }
+
+        stop() {
+            this._running = false;
+            if (this._monitor) {
+                try { this._monitor.stop(); } catch (e) {}
+                this._monitor = null;
+            }
+            for (const [, state] of this._readers) {
+                if (state.card) {
+                    try { state.card.disconnect(); } catch (e) {}
+                }
+            }
+            this._readers.clear();
+            if (this._context) {
+                try { this._context.close(); } catch (e) {}
+                this._context = null;
+            }
+        }
+
+        listReaders() {
+            if (!this._context || !this._context.isValid) return [];
+            try { return this._context.listReaders(); } catch (e) { return []; }
+        }
+
+        _handleEvent(event) {
+            this._eventQueue = this._eventQueue.then(() => this._processEvent(event));
+        }
+
+        async _processEvent(event) {
+            if (!this._running) return;
+            const { type, reader: readerName, state, atr } = event;
+
+            switch (type) {
+                case 'reader-attached':
+                    await this._handleReaderAttached(readerName, state, atr);
+                    break;
+                case 'reader-detached':
+                    this._handleReaderDetached(readerName);
+                    break;
+                case 'card-inserted':
+                    await this._handleCardInserted(readerName, state, atr);
+                    break;
+                case 'card-removed':
+                    this._handleCardRemoved(readerName);
+                    break;
+                case 'error':
+                    this.emit('error', new Error(readerName));
+                    break;
+            }
+        }
+
+        async _handleReaderAttached(readerName, state, atr) {
+            this._readers.set(readerName, { hasCard: false, card: null });
+            this.emit('reader-attached', { name: readerName, state, atr });
+            if ((state & SCARD_STATE_PRESENT) !== 0) {
+                await this._handleCardInserted(readerName, state, atr);
+            }
+        }
+
+        _handleReaderDetached(readerName) {
+            const state = this._readers.get(readerName);
+            if (state?.hasCard) this._handleCardRemoved(readerName);
+            this._readers.delete(readerName);
+            this.emit('reader-detached', { name: readerName });
+        }
+
+        async _handleCardInserted(readerName, eventState, atr) {
+            let state = this._readers.get(readerName);
+            if (!state) {
+                state = { hasCard: false, card: null };
+                this._readers.set(readerName, state);
+            }
+            state.hasCard = true;
+
+            try {
+                const readers = this._context.listReaders();
+                const reader = readers.find(r => r.name === readerName);
+                if (reader) {
+                    const card = await reader.connect(SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1);
+                    state.card = card;
+                    this.emit('card-inserted', {
+                        reader: { name: readerName, state: eventState, atr },
+                        card,
+                    });
+                }
+            } catch (err) {
+                this.emit('error', err);
+            }
+        }
+
+        _handleCardRemoved(readerName) {
+            const state = this._readers.get(readerName);
+            if (!state) return;
+            const card = state.card;
+            state.hasCard = false;
+            state.card = null;
+            if (card) try { card.disconnect(); } catch (e) {}
+            this.emit('card-removed', { reader: { name: readerName }, card });
+        }
+
+        /** @returns {MockReaderMonitor|null} */
+        get _mockMonitor() {
+            return this._monitor;
+        }
+    }
+
+    return MockDevices;
+}
+
+module.exports = {
+    MockCard,
+    MockReader,
+    MockContext,
+    MockReaderMonitor,
+    createMockDevices,
+};

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,0 +1,508 @@
+'use strict';
+
+const assert = require('assert');
+const {
+    MockCard,
+    MockReader,
+    MockContext,
+    MockReaderMonitor,
+    createMockDevices,
+} = require('./mock');
+
+// Test results
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  [PASS] ${name}`);
+        passed++;
+    } catch (err) {
+        console.log(`  [FAIL] ${name}: ${err.message}`);
+        failed++;
+    }
+}
+
+async function testAsync(name, fn) {
+    try {
+        await fn();
+        console.log(`  [PASS] ${name}`);
+        passed++;
+    } catch (err) {
+        console.log(`  [FAIL] ${name}: ${err.message}`);
+        failed++;
+    }
+}
+
+(async () => {
+
+console.log('\n=== Unit Tests (Mock-based, no hardware required) ===\n');
+
+// ============================================================================
+// MockCard Tests
+// ============================================================================
+
+console.log('MockCard Tests:');
+
+test('should create a mock card with protocol and ATR', () => {
+    const atr = Buffer.from([0x3B, 0x8F, 0x80, 0x01]);
+    const card = new MockCard(1, atr);
+
+    assert.strictEqual(card.protocol, 1);
+    assert.strictEqual(card.connected, true);
+    assert(card.atr.equals(atr));
+});
+
+test('should disconnect card', () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    assert.strictEqual(card.connected, true);
+
+    card.disconnect();
+    assert.strictEqual(card.connected, false);
+    assert.strictEqual(card.atr, null);
+});
+
+await testAsync('should transmit APDU and return configured response', async () => {
+    const card = new MockCard(1, Buffer.from([0x3B]), [
+        {
+            command: [0xFF, 0xCA, 0x00, 0x00, 0x00],
+            response: [0x04, 0xA2, 0x3B, 0x7A, 0x90, 0x00],
+        },
+    ]);
+
+    const response = await card.transmit([0xFF, 0xCA, 0x00, 0x00, 0x00]);
+    assert(response.equals(Buffer.from([0x04, 0xA2, 0x3B, 0x7A, 0x90, 0x00])));
+});
+
+await testAsync('should return default success for unknown commands', async () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    const response = await card.transmit([0x00, 0xA4, 0x04, 0x00]);
+    assert(response.equals(Buffer.from([0x90, 0x00])));
+});
+
+await testAsync('should throw when transmitting on disconnected card', async () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    card.disconnect();
+
+    try {
+        await card.transmit([0xFF, 0xCA, 0x00, 0x00, 0x00]);
+        assert.fail('Should have thrown');
+    } catch (err) {
+        assert.strictEqual(err.message, 'Card is not connected');
+    }
+});
+
+test('should get card status', () => {
+    const atr = Buffer.from([0x3B, 0x8F]);
+    const card = new MockCard(2, atr);
+
+    const status = card.getStatus();
+    assert.strictEqual(status.protocol, 2);
+    assert(status.atr.equals(atr));
+    assert.strictEqual(typeof status.state, 'number');
+});
+
+test('should reconnect card', () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    card.disconnect();
+    assert.strictEqual(card.connected, false);
+
+    const protocol = card.reconnect();
+    assert.strictEqual(card.connected, true);
+    assert.strictEqual(protocol, 1);
+});
+
+// ============================================================================
+// MockReader Tests
+// ============================================================================
+
+console.log('\nMockReader Tests:');
+
+test('should create reader without card', () => {
+    const reader = new MockReader('Test Reader');
+
+    assert.strictEqual(reader.name, 'Test Reader');
+    assert.strictEqual(reader.atr, null);
+    assert.strictEqual(reader.state & 0x20, 0); // Not PRESENT
+});
+
+test('should create reader with card', () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    const reader = new MockReader('Test Reader', card);
+
+    assert.strictEqual(reader.name, 'Test Reader');
+    assert(reader.atr.equals(Buffer.from([0x3B])));
+    assert.strictEqual(reader.state & 0x20, 0x20); // PRESENT (0x100 | 0x20 | 0x02)
+});
+
+await testAsync('should connect to card', async () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    const reader = new MockReader('Test Reader', card);
+
+    const connectedCard = await reader.connect(2, 3);
+    assert.strictEqual(connectedCard, card);
+});
+
+await testAsync('should throw when connecting without card', async () => {
+    const reader = new MockReader('Test Reader');
+
+    try {
+        await reader.connect();
+        assert.fail('Should have thrown');
+    } catch (err) {
+        assert.strictEqual(err.message, 'No card in reader');
+    }
+});
+
+test('should insert and remove cards', () => {
+    const reader = new MockReader('Test Reader');
+    assert.strictEqual(reader.atr, null);
+
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    reader.insertCard(card);
+    assert(reader.atr.equals(Buffer.from([0x3B])));
+
+    reader.removeCard();
+    assert.strictEqual(reader.atr, null);
+});
+
+// ============================================================================
+// MockContext Tests
+// ============================================================================
+
+console.log('\nMockContext Tests:');
+
+test('should create valid context', () => {
+    const ctx = new MockContext();
+    assert.strictEqual(ctx.isValid, true);
+});
+
+test('should close context', () => {
+    const ctx = new MockContext();
+    ctx.close();
+    assert.strictEqual(ctx.isValid, false);
+});
+
+test('should list readers', () => {
+    const ctx = new MockContext();
+    const reader1 = new MockReader('Reader 1');
+    const reader2 = new MockReader('Reader 2');
+
+    ctx.addReader(reader1);
+    ctx.addReader(reader2);
+
+    const readers = ctx.listReaders();
+    assert.strictEqual(readers.length, 2);
+    assert.strictEqual(readers[0].name, 'Reader 1');
+    assert.strictEqual(readers[1].name, 'Reader 2');
+});
+
+test('should remove readers', () => {
+    const ctx = new MockContext();
+    ctx.addReader(new MockReader('Reader 1'));
+    ctx.addReader(new MockReader('Reader 2'));
+
+    ctx.removeReader('Reader 1');
+
+    const readers = ctx.listReaders();
+    assert.strictEqual(readers.length, 1);
+    assert.strictEqual(readers[0].name, 'Reader 2');
+});
+
+test('should throw when listing readers on closed context', () => {
+    const ctx = new MockContext();
+    ctx.close();
+
+    try {
+        ctx.listReaders();
+        assert.fail('Should have thrown');
+    } catch (err) {
+        assert.strictEqual(err.message, 'Context is not valid');
+    }
+});
+
+// ============================================================================
+// MockReaderMonitor Tests
+// ============================================================================
+
+console.log('\nMockReaderMonitor Tests:');
+
+test('should start and stop monitoring', () => {
+    const monitor = new MockReaderMonitor();
+
+    assert.strictEqual(monitor.isRunning, false);
+
+    monitor.start(() => {});
+    assert.strictEqual(monitor.isRunning, true);
+
+    monitor.stop();
+    assert.strictEqual(monitor.isRunning, false);
+});
+
+test('should throw when starting already running monitor', () => {
+    const monitor = new MockReaderMonitor();
+    monitor.start(() => {});
+
+    try {
+        monitor.start(() => {});
+        assert.fail('Should have thrown');
+    } catch (err) {
+        assert.strictEqual(err.message, 'Monitor is already running');
+    }
+
+    monitor.stop();
+});
+
+test('should emit reader-attached for existing readers on start', () => {
+    const monitor = new MockReaderMonitor();
+    const reader = new MockReader('Test Reader');
+    monitor.attachReader(reader);
+
+    const events = [];
+    monitor.start((event) => events.push(event));
+
+    assert.strictEqual(events.length, 1);
+    assert.strictEqual(events[0].type, 'reader-attached');
+    assert.strictEqual(events[0].reader, 'Test Reader');
+
+    monitor.stop();
+});
+
+test('should emit events when attaching/detaching readers', () => {
+    const monitor = new MockReaderMonitor();
+    const events = [];
+
+    monitor.start((event) => events.push(event));
+
+    const reader = new MockReader('Test Reader');
+    monitor.attachReader(reader);
+
+    assert.strictEqual(events.length, 1);
+    assert.strictEqual(events[0].type, 'reader-attached');
+
+    monitor.detachReader('Test Reader');
+
+    assert.strictEqual(events.length, 2);
+    assert.strictEqual(events[1].type, 'reader-detached');
+
+    monitor.stop();
+});
+
+test('should emit events when inserting/removing cards', () => {
+    const monitor = new MockReaderMonitor();
+    const events = [];
+
+    const reader = new MockReader('Test Reader');
+    monitor.attachReader(reader);
+
+    monitor.start((event) => events.push(event));
+    events.length = 0; // Clear the reader-attached event
+
+    const card = new MockCard(1, Buffer.from([0x3B, 0x8F]));
+    monitor.insertCard('Test Reader', card);
+
+    assert.strictEqual(events.length, 1);
+    assert.strictEqual(events[0].type, 'card-inserted');
+    assert(events[0].atr.equals(Buffer.from([0x3B, 0x8F])));
+
+    monitor.removeCard('Test Reader');
+
+    assert.strictEqual(events.length, 2);
+    assert.strictEqual(events[1].type, 'card-removed');
+
+    monitor.stop();
+});
+
+// ============================================================================
+// MockDevices Integration Tests
+// ============================================================================
+
+console.log('\nMockDevices Integration Tests:');
+
+await testAsync('should emit reader-attached events', async () => {
+    const mockContext = new MockContext();
+    const mockMonitor = new MockReaderMonitor();
+    const mockReader = new MockReader('ACR122U');
+
+    mockContext.addReader(mockReader);
+    mockMonitor.attachReader(mockReader);
+
+    const MockDevices = createMockDevices({
+        Context: function() { return mockContext; },
+        ReaderMonitor: function() { return mockMonitor; },
+    });
+
+    const devices = new MockDevices();
+    const events = [];
+
+    devices.on('reader-attached', (reader) => events.push({ type: 'reader-attached', reader }));
+
+    devices.start();
+
+    // Wait for events to process
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    assert.strictEqual(events.length, 1);
+    assert.strictEqual(events[0].type, 'reader-attached');
+    assert.strictEqual(events[0].reader.name, 'ACR122U');
+
+    devices.stop();
+});
+
+await testAsync('should emit card-inserted events with card object', async () => {
+    const mockCard = new MockCard(1, Buffer.from([0x3B, 0x8F, 0x80, 0x01]), [
+        { command: [0xFF, 0xCA, 0x00, 0x00, 0x00], response: [0x04, 0xA2, 0x90, 0x00] },
+    ]);
+    const mockReader = new MockReader('ACR122U', mockCard);
+    const mockContext = new MockContext();
+    const mockMonitor = new MockReaderMonitor();
+
+    mockContext.addReader(mockReader);
+    mockMonitor.attachReader(mockReader);
+
+    const MockDevices = createMockDevices({
+        Context: function() { return mockContext; },
+        ReaderMonitor: function() { return mockMonitor; },
+    });
+
+    const devices = new MockDevices();
+    const events = [];
+
+    devices.on('card-inserted', (event) => events.push(event));
+
+    devices.start();
+
+    // Wait for events to process
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert.strictEqual(events.length, 1);
+    assert.strictEqual(events[0].reader.name, 'ACR122U');
+    assert(events[0].card);
+
+    // Test transmit
+    const response = await events[0].card.transmit([0xFF, 0xCA, 0x00, 0x00, 0x00]);
+    assert(response.equals(Buffer.from([0x04, 0xA2, 0x90, 0x00])));
+
+    devices.stop();
+});
+
+await testAsync('should emit card-removed events', async () => {
+    const mockCard = new MockCard(1, Buffer.from([0x3B]));
+    const mockReader = new MockReader('ACR122U', mockCard);
+    const mockContext = new MockContext();
+    const mockMonitor = new MockReaderMonitor();
+
+    mockContext.addReader(mockReader);
+    mockMonitor.attachReader(mockReader);
+
+    const MockDevices = createMockDevices({
+        Context: function() { return mockContext; },
+        ReaderMonitor: function() { return mockMonitor; },
+    });
+
+    const devices = new MockDevices();
+    const events = [];
+
+    devices.on('card-inserted', () => events.push('inserted'));
+    devices.on('card-removed', () => events.push('removed'));
+
+    devices.start();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // Simulate card removal
+    mockMonitor.removeCard('ACR122U');
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert(events.includes('inserted'));
+    assert(events.includes('removed'));
+
+    devices.stop();
+});
+
+await testAsync('should handle multiple readers', async () => {
+    const mockContext = new MockContext();
+    const mockMonitor = new MockReaderMonitor();
+
+    const reader1 = new MockReader('Reader 1', new MockCard(1, Buffer.from([0x3B])));
+    const reader2 = new MockReader('Reader 2', new MockCard(2, Buffer.from([0x3C])));
+
+    mockContext.addReader(reader1);
+    mockContext.addReader(reader2);
+    mockMonitor.attachReader(reader1);
+    mockMonitor.attachReader(reader2);
+
+    const MockDevices = createMockDevices({
+        Context: function() { return mockContext; },
+        ReaderMonitor: function() { return mockMonitor; },
+    });
+
+    const devices = new MockDevices();
+    const readerEvents = [];
+    const cardEvents = [];
+
+    devices.on('reader-attached', (r) => readerEvents.push(r.name));
+    devices.on('card-inserted', (e) => cardEvents.push(e.reader.name));
+
+    devices.start();
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    assert.strictEqual(readerEvents.length, 2);
+    assert(readerEvents.includes('Reader 1'));
+    assert(readerEvents.includes('Reader 2'));
+
+    assert.strictEqual(cardEvents.length, 2);
+    assert(cardEvents.includes('Reader 1'));
+    assert(cardEvents.includes('Reader 2'));
+
+    devices.stop();
+});
+
+await testAsync('should emit reader-detached events', async () => {
+    const mockContext = new MockContext();
+    const mockMonitor = new MockReaderMonitor();
+    const reader = new MockReader('ACR122U');
+
+    mockContext.addReader(reader);
+    mockMonitor.attachReader(reader);
+
+    const MockDevices = createMockDevices({
+        Context: function() { return mockContext; },
+        ReaderMonitor: function() { return mockMonitor; },
+    });
+
+    const devices = new MockDevices();
+    const events = [];
+
+    devices.on('reader-attached', () => events.push('attached'));
+    devices.on('reader-detached', () => events.push('detached'));
+
+    devices.start();
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    mockMonitor.detachReader('ACR122U');
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    assert(events.includes('attached'));
+    assert(events.includes('detached'));
+
+    devices.stop();
+});
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+console.log('\n=== Unit Test Summary ===');
+console.log(`  Passed: ${passed}`);
+console.log(`  Failed: ${failed}`);
+console.log('');
+
+if (failed > 0) {
+    process.exit(1);
+}
+
+})().catch(err => {
+    console.error('Test error:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `test/mock.js` with MockCard, MockReader, MockContext, MockReaderMonitor classes that simulate PC/SC behavior
- Add `test/unit.js` with 27 unit tests that run without hardware
- Update `package.json` with separate test scripts:
  - `npm run test:unit` - runs unit tests only (no hardware needed)
  - `npm run test:integration` - runs hardware-dependent tests
  - `npm test` - runs both

## Test plan

- [x] Run `npm run test:unit` - should pass without any hardware
- [x] Run `npm run test:integration` - should work as before
- [x] Run `npm test` - should run both test suites

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)