### PR TITLE
Add createPCSCError factory function for typed errors

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -67,6 +67,32 @@ class SharingViolationError extends PCSCError {
     }
 }
 
+/**
+ * PC/SC error codes mapped to specific error classes
+ * @type {Map<number, typeof PCSCError>}
+ */
+const ERROR_CODE_MAP = new Map([
+    [0x80100069, CardRemovedError],      // SCARD_W_REMOVED_CARD
+    [0x8010000A, TimeoutError],           // SCARD_E_TIMEOUT
+    [0x8010002E, NoReadersError],         // SCARD_E_NO_READERS_AVAILABLE
+    [0x8010001D, ServiceNotRunningError], // SCARD_E_NO_SERVICE
+    [0x8010000B, SharingViolationError],  // SCARD_E_SHARING_VIOLATION
+]);
+
+/**
+ * Factory function to create the appropriate error class based on PC/SC error code
+ * @param {string} message - Error message
+ * @param {number} code - PC/SC error code
+ * @returns {PCSCError} The appropriate error instance
+ */
+function createPCSCError(message, code) {
+    const ErrorClass = ERROR_CODE_MAP.get(code);
+    if (ErrorClass) {
+        return new ErrorClass(message);
+    }
+    return new PCSCError(message, code);
+}
+
 module.exports = {
     PCSCError,
     CardRemovedError,
@@ -74,4 +100,5 @@ module.exports = {
     NoReadersError,
     ServiceNotRunningError,
     SharingViolationError,
+    createPCSCError,
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -216,6 +216,32 @@ export declare class TimeoutError extends PCSCError {
     constructor(message?: string);
 }
 
+/**
+ * Error thrown when no readers are available
+ */
+export declare class NoReadersError extends PCSCError {
+    constructor(message?: string);
+}
+
+/**
+ * Error thrown when PC/SC service is not running
+ */
+export declare class ServiceNotRunningError extends PCSCError {
+    constructor(message?: string);
+}
+
+/**
+ * Error thrown when there's a sharing violation
+ */
+export declare class SharingViolationError extends PCSCError {
+    constructor(message?: string);
+}
+
+/**
+ * Factory function to create the appropriate error class based on PC/SC error code
+ */
+export declare function createPCSCError(message: string, code: number): PCSCError;
+
 // Share modes
 export declare const SCARD_SHARE_EXCLUSIVE: number;
 export declare const SCARD_SHARE_SHARED: number;

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,15 @@ const SCARD_STATE_MUTE = addon.SCARD_STATE_MUTE;
 const { Devices } = require('./devices');
 
 // Import error classes
-const { PCSCError, CardRemovedError, TimeoutError } = require('./errors');
+const {
+    PCSCError,
+    CardRemovedError,
+    TimeoutError,
+    NoReadersError,
+    ServiceNotRunningError,
+    SharingViolationError,
+    createPCSCError,
+} = require('./errors');
 
 module.exports = {
     // Classes
@@ -52,6 +60,10 @@ module.exports = {
     PCSCError,
     CardRemovedError,
     TimeoutError,
+    NoReadersError,
+    ServiceNotRunningError,
+    SharingViolationError,
+    createPCSCError,
 
     // Share modes
     SCARD_SHARE_EXCLUSIVE,

--- a/test/unit.js
+++ b/test/unit.js
@@ -490,6 +490,101 @@ await testAsync('should emit reader-detached events', async () => {
 });
 
 // ============================================================================
+// Error Class Tests
+// ============================================================================
+
+console.log('\nError Class Tests:');
+
+const {
+    PCSCError,
+    CardRemovedError,
+    TimeoutError,
+    NoReadersError,
+    ServiceNotRunningError,
+    SharingViolationError,
+    createPCSCError,
+} = require('../lib/errors');
+
+test('PCSCError should have code property', () => {
+    const err = new PCSCError('Test error', 0x80100001);
+    assert.strictEqual(err.code, 0x80100001);
+    assert.strictEqual(err.name, 'PCSCError');
+    assert.strictEqual(err.message, 'Test error');
+});
+
+test('CardRemovedError should have correct code', () => {
+    const err = new CardRemovedError();
+    assert.strictEqual(err.code, 0x80100069);
+    assert.strictEqual(err.name, 'CardRemovedError');
+    assert(err instanceof PCSCError);
+});
+
+test('TimeoutError should have correct code', () => {
+    const err = new TimeoutError();
+    assert.strictEqual(err.code, 0x8010000A);
+    assert.strictEqual(err.name, 'TimeoutError');
+    assert(err instanceof PCSCError);
+});
+
+test('NoReadersError should have correct code', () => {
+    const err = new NoReadersError();
+    assert.strictEqual(err.code, 0x8010002E);
+    assert.strictEqual(err.name, 'NoReadersError');
+    assert(err instanceof PCSCError);
+});
+
+test('ServiceNotRunningError should have correct code', () => {
+    const err = new ServiceNotRunningError();
+    assert.strictEqual(err.code, 0x8010001D);
+    assert.strictEqual(err.name, 'ServiceNotRunningError');
+    assert(err instanceof PCSCError);
+});
+
+test('SharingViolationError should have correct code', () => {
+    const err = new SharingViolationError();
+    assert.strictEqual(err.code, 0x8010000B);
+    assert.strictEqual(err.name, 'SharingViolationError');
+    assert(err instanceof PCSCError);
+});
+
+test('createPCSCError should return CardRemovedError for 0x80100069', () => {
+    const err = createPCSCError('Card was removed', 0x80100069);
+    assert(err instanceof CardRemovedError);
+    assert.strictEqual(err.code, 0x80100069);
+});
+
+test('createPCSCError should return TimeoutError for 0x8010000A', () => {
+    const err = createPCSCError('Timeout', 0x8010000A);
+    assert(err instanceof TimeoutError);
+    assert.strictEqual(err.code, 0x8010000A);
+});
+
+test('createPCSCError should return NoReadersError for 0x8010002E', () => {
+    const err = createPCSCError('No readers', 0x8010002E);
+    assert(err instanceof NoReadersError);
+    assert.strictEqual(err.code, 0x8010002E);
+});
+
+test('createPCSCError should return ServiceNotRunningError for 0x8010001D', () => {
+    const err = createPCSCError('Service not running', 0x8010001D);
+    assert(err instanceof ServiceNotRunningError);
+    assert.strictEqual(err.code, 0x8010001D);
+});
+
+test('createPCSCError should return SharingViolationError for 0x8010000B', () => {
+    const err = createPCSCError('Sharing violation', 0x8010000B);
+    assert(err instanceof SharingViolationError);
+    assert.strictEqual(err.code, 0x8010000B);
+});
+
+test('createPCSCError should return PCSCError for unknown codes', () => {
+    const err = createPCSCError('Unknown error', 0x80100099);
+    assert(err instanceof PCSCError);
+    assert(!(err instanceof CardRemovedError));
+    assert.strictEqual(err.code, 0x80100099);
+});
+
+// ============================================================================
 // Summary
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Add `createPCSCError(message, code)` factory function that returns the appropriate error subclass based on PC/SC error codes
- Export previously unexported error classes: `NoReadersError`, `ServiceNotRunningError`, `SharingViolationError`
- Update TypeScript definitions with new exports
- Add 12 unit tests for error classes and factory function

## Usage

```javascript
const { createPCSCError, CardRemovedError } = require('smartcard');

try {
    await card.transmit([...]);
} catch (err) {
    // Now you can use instanceof checks
    if (err instanceof CardRemovedError) {
        console.log('Card was removed, code:', err.code);
    }
}
```

## Test plan

- [x] Run `npm run test:unit` - all 39 tests pass
- [x] Verify factory returns correct error types for known codes
- [x] Verify factory returns PCSCError for unknown codes

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)