### PR TITLE
Add configurable receive buffer size for transmit

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -22,6 +22,18 @@ export interface CardStatus {
 }
 
 /**
+ * Options for card.transmit()
+ */
+export interface TransmitOptions {
+    /**
+     * Maximum receive buffer size in bytes.
+     * Default: 258 (standard APDU: 256 data + 2 status bytes)
+     * Maximum: 262144 (256KB for extended APDUs)
+     */
+    maxRecvLength?: number;
+}
+
+/**
  * Represents a connected smart card
  */
 export interface Card {
@@ -35,9 +47,10 @@ export interface Card {
     /**
      * Transmit an APDU command to the card
      * @param command - The command buffer or byte array
+     * @param options - Optional transmit options
      * @returns Promise resolving to the response buffer
      */
-    transmit(command: Buffer | number[]): Promise<Buffer>;
+    transmit(command: Buffer | number[], options?: TransmitOptions): Promise<Buffer>;
 
     /**
      * Send a control command to the reader

--- a/src/async_workers.h
+++ b/src/async_workers.h
@@ -35,6 +35,7 @@ public:
                    SCARDHANDLE card,
                    DWORD protocol,
                    std::vector<uint8_t> sendBuffer,
+                   size_t maxRecvLength,
                    Napi::Promise::Deferred deferred);
 
     void Execute() override;

--- a/test/mock.js
+++ b/test/mock.js
@@ -42,12 +42,17 @@ class MockCard {
 
     /**
      * @param {Buffer|number[]} command
+     * @param {Object} [options]
+     * @param {number} [options.maxRecvLength]
      * @returns {Promise<Buffer>}
      */
-    async transmit(command) {
+    async transmit(command, options = {}) {
         if (!this._connected) {
             throw new Error('Card is not connected');
         }
+
+        // Store options for testing
+        this._lastTransmitOptions = options;
 
         const cmdBuffer = Buffer.isBuffer(command) ? command : Buffer.from(command);
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -113,6 +113,18 @@ test('should reconnect card', () => {
     assert.strictEqual(protocol, 1);
 });
 
+await testAsync('should accept maxRecvLength option in transmit', async () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    await card.transmit([0xFF, 0xCA, 0x00, 0x00, 0x00], { maxRecvLength: 65536 });
+    assert.strictEqual(card._lastTransmitOptions.maxRecvLength, 65536);
+});
+
+await testAsync('should use default options when none provided', async () => {
+    const card = new MockCard(1, Buffer.from([0x3B]));
+    await card.transmit([0xFF, 0xCA, 0x00, 0x00, 0x00]);
+    assert.deepStrictEqual(card._lastTransmitOptions, {});
+});
+
 // ============================================================================
 // MockReader Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add optional `maxRecvLength` option to `card.transmit()` for configurable receive buffer size
- Default: 258 bytes (standard APDU: 256 data + 2 status bytes)
- Maximum: 262144 bytes (256KB for extended APDUs)
- Updated TypeScript definitions with `TransmitOptions` interface
- Added unit tests for the new option

## Usage

```javascript
// Standard usage (default 258 byte buffer)
const response = await card.transmit(command);

// Extended APDU with larger buffer
const response = await card.transmit(command, { maxRecvLength: 65536 });
```

## Test plan

- [x] Build native module successfully
- [x] Run `npm run test:unit` - all 41 tests pass
- [x] Mock tests verify option is passed through

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)