### PR TITLE
Fix Windows compilation: define MAX_ATR_SIZE if not available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    # Windows builds have a pre-existing compilation issue (MAX_ATR_SIZE undeclared)
-    # Allow Windows to fail until that's fixed
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/platform/pcsc.h
+++ b/src/platform/pcsc.h
@@ -32,5 +32,10 @@
     #endif
 #endif
 
+// MAX_ATR_SIZE may not be defined on some Windows SDK versions
+#ifndef MAX_ATR_SIZE
+    #define MAX_ATR_SIZE 33
+#endif
+
 // Helper macro for unused parameters
 #define PCSC_UNUSED(x) (void)(x)


### PR DESCRIPTION
## Summary
- Define `MAX_ATR_SIZE` (33 bytes per ISO 7816-3) if not available from Windows SDK
- Remove `continue-on-error` from Windows CI builds

## Problem
Windows builds were failing with:
```
error C2065: 'MAX_ATR_SIZE': undeclared identifier
```

The `MAX_ATR_SIZE` constant is used in `pcsc_card.cpp` to size ATR buffers, but may not be defined on all Windows SDK versions.

## Solution
Add a fallback definition in `src/platform/pcsc.h`:
```cpp
#ifndef MAX_ATR_SIZE
    #define MAX_ATR_SIZE 33
#endif
```

This is the correct value per ISO 7816-3 which specifies maximum ATR length of 33 bytes.

## Test plan
- [ ] Windows CI builds pass for Node 18, 20, 22
- [ ] macOS and Linux builds continue to work

Fixes #63