### PR TITLE
Add exports field for modern bundler compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "homepage": "https://github.com/tomkp/smartcard#readme",
     "main": "dist/lib/index.js",
     "types": "dist/lib/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/lib/index.d.ts",
+            "require": "./dist/lib/index.js"
+        }
+    },
     "gypfile": true,
     "scripts": {
         "install": "node-gyp rebuild",


### PR DESCRIPTION
## Summary
Add package.json exports field for proper module resolution in modern bundlers and TypeScript projects.

## Changes
- Add `exports` field with proper subpath exports
- Types condition listed first for TypeScript resolution
- Maintains backward compatibility with existing `main`/`types` fields

## Why
Modern bundlers (webpack 5+, Vite, Rollup) and Node.js use the `exports` field for module resolution. This enables proper resolution for both TypeScript and CommonJS consumers.

Fixes #70