### PR TITLE
Fix Reconnect to update Card object's protocol after success

### DIFF
--- a/src/async_workers.cpp
+++ b/src/async_workers.cpp
@@ -252,6 +252,7 @@ ReconnectWorker::ReconnectWorker(
     DWORD shareMode,
     DWORD preferredProtocols,
     DWORD initialization,
+    DWORD* protocolOut,
     Napi::Promise::Deferred deferred)
     : Napi::AsyncWorker(env),
       card_(card),
@@ -259,6 +260,7 @@ ReconnectWorker::ReconnectWorker(
       preferredProtocols_(preferredProtocols),
       initialization_(initialization),
       activeProtocol_(0),
+      protocolOut_(protocolOut),
       result_(SCARD_S_SUCCESS),
       deferred_(deferred) {
 }
@@ -277,6 +279,10 @@ void ReconnectWorker::OnOK() {
     Napi::Env env = Env();
 
     if (result_ == SCARD_S_SUCCESS) {
+        // Update the card object's protocol
+        if (protocolOut_) {
+            *protocolOut_ = activeProtocol_;
+        }
         deferred_.Resolve(Napi::Number::New(env, activeProtocol_));
     } else {
         deferred_.Reject(Napi::Error::New(env, GetPCSCErrorString(result_)).Value());

--- a/src/async_workers.h
+++ b/src/async_workers.h
@@ -108,6 +108,7 @@ public:
                     DWORD shareMode,
                     DWORD preferredProtocols,
                     DWORD initialization,
+                    DWORD* protocolOut,
                     Napi::Promise::Deferred deferred);
 
     void Execute() override;
@@ -122,6 +123,7 @@ private:
     DWORD preferredProtocols_;
     DWORD initialization_;
     DWORD activeProtocol_;
+    DWORD* protocolOut_;
     LONG result_;
     Napi::Promise::Deferred deferred_;
 };

--- a/src/pcsc_card.cpp
+++ b/src/pcsc_card.cpp
@@ -248,7 +248,7 @@ Napi::Value PCSCCard::Reconnect(const Napi::CallbackInfo& info) {
     Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
 
     ReconnectWorker* worker = new ReconnectWorker(
-        env, card_, shareMode, preferredProtocols, initialization, deferred);
+        env, card_, shareMode, preferredProtocols, initialization, &protocol_, deferred);
     worker->Queue();
 
     return deferred.Promise();

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -82,6 +82,22 @@ describe('MockCard', () => {
         assert.strictEqual(protocol, 1);
     });
 
+    it('should update protocol after reconnect with different protocol', async () => {
+        const card = new MockCard(1, Buffer.from([0x3b])); // Start with T=0 (protocol 1)
+        assert.strictEqual(card.protocol, 1);
+
+        // Simulate reconnection with T=1 protocol
+        card.setReconnectProtocol(2);
+        const newProtocol = await card.reconnect();
+
+        assert.strictEqual(newProtocol, 2, 'reconnect should return new protocol');
+        assert.strictEqual(
+            card.protocol,
+            2,
+            'card.protocol should be updated after reconnect'
+        );
+    });
+
     it('should accept maxRecvLength option in transmit', async () => {
         const card = new MockCard(1, Buffer.from([0x3b]));
         await card.transmit([0xff, 0xca, 0x00, 0x00, 0x00], {


### PR DESCRIPTION
## Summary
Fix a bug where the `PCSCCard` object's `protocol` property was not updated after a successful `reconnect()` call.

## Problem
When calling `card.reconnect()`, the new protocol was returned but the card object's internal `protocol_` member remained unchanged. This meant `card.protocol` would return a stale value after reconnection.

## Solution
- Pass a pointer to `protocol_` to the `ReconnectWorker`
- Update the protocol in the worker's `OnOK()` callback (which runs on the main thread)
- The card object now correctly reflects the new protocol after reconnect

## Test
Added a new test case that verifies `card.protocol` is updated after reconnect.

Fixes #72