### PR TITLE
fix: add explicit buffer bounds validation in parseFeatures()

### DIFF
--- a/lib/control-codes.ts
+++ b/lib/control-codes.ts
@@ -47,11 +47,16 @@ export function parseFeatures(response: Buffer): Map<number, number> {
     const features = new Map<number, number>();
     let offset = 0;
 
-    while (offset + 4 <= response.length) {
+    while (offset + 2 <= response.length) {
         const tag = response[offset];
         const length = response[offset + 1];
 
-        if (length === 4 && offset + 2 + length <= response.length) {
+        // Validate length doesn't exceed remaining buffer
+        if (offset + 2 + length > response.length) {
+            break;
+        }
+
+        if (length === 4) {
             // Big-endian control code
             const controlCode =
                 (response[offset + 2] << 24) |

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -947,6 +947,24 @@ describe('parseFeatures (Issue #86)', () => {
         assert.strictEqual(features.get(0x0a), 0x4233000a);
         assert.strictEqual(features.get(0x12), 0x42330012);
     });
+
+    it('should not read beyond buffer with malformed length field', () => {
+        // TLV with length=255 (would read way beyond buffer if not validated)
+        const tlv = Buffer.from([0x06, 0xff, 0x42, 0x00, 0x0D, 0x48]);
+        const features = parseFeatures(tlv);
+
+        // Should safely skip this malformed entry and not crash
+        assert.strictEqual(features.size, 0, 'Should return empty map for malformed length');
+    });
+
+    it('should handle length that exactly exceeds remaining bytes', () => {
+        // TLV says length=6 but only 4 bytes remain
+        const tlv = Buffer.from([0x06, 0x06, 0x42, 0x00, 0x0D, 0x48]);
+        const features = parseFeatures(tlv);
+
+        // length != 4, so should be skipped anyway
+        assert.strictEqual(features.size, 0, 'Should skip non-4 length entries');
+    });
 });
 
 describe('Package Exports (Issue #78)', () => {


### PR DESCRIPTION
## Summary
Adds explicit buffer bounds validation in `parseFeatures()` to prevent potential buffer overread with malformed TLV data.

## Changes
- Change loop condition to check for minimum TLV header (2 bytes)
- Add explicit break when length field exceeds remaining buffer
- Simplifies logic by separating bounds check from length==4 check
- Add tests for malformed length fields

## Test plan
- [x] All 80 unit tests pass
- [x] Coverage maintained at 95.89% for control-codes.ts

Fixes #88