### PR TITLE
refactor: consolidate addon type definitions to use NativeAddon interface

### DIFF
--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -6,19 +6,13 @@ import type {
     DeviceEvents,
     DevicesOptions,
     MonitorEvent,
+    NativeAddon,
     Reader,
     ReaderMonitor,
     ReaderMonitorConstructor,
 } from './types';
 
-const addon = require('../../build/Release/smartcard_napi.node') as {
-    Context: ContextConstructor;
-    ReaderMonitor: ReaderMonitorConstructor;
-    SCARD_STATE_PRESENT: number;
-    SCARD_SHARE_SHARED: number;
-    SCARD_PROTOCOL_T0: number;
-    SCARD_PROTOCOL_T1: number;
-};
+const addon = require('../../build/Release/smartcard_napi.node') as NativeAddon;
 
 interface ReaderStateInternal {
     hasCard: boolean;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,17 @@
+import type {
+    ContextConstructor,
+    NativeAddon,
+    ReaderMonitorConstructor,
+} from './types';
+
 // Load native addon
-const addon = require('../../build/Release/smartcard_napi.node') as import('./types').NativeAddon;
+const addon = require('../../build/Release/smartcard_napi.node') as NativeAddon;
 
 // Re-export native classes
-export const Context =
-    addon.Context as import('./types').ContextConstructor;
+export const Context = addon.Context as ContextConstructor;
 export const Reader = addon.Reader;
 export const Card = addon.Card;
-export const ReaderMonitor =
-    addon.ReaderMonitor as import('./types').ReaderMonitorConstructor;
+export const ReaderMonitor = addon.ReaderMonitor as ReaderMonitorConstructor;
 
 // Re-export constants
 export const SCARD_SHARE_EXCLUSIVE = addon.SCARD_SHARE_EXCLUSIVE;


### PR DESCRIPTION
## Summary
Use the `NativeAddon` interface from `types.ts` consistently in both `index.ts` and `devices.ts` instead of inline type definitions.

## Changes
- Update `devices.ts` to import `NativeAddon` type
- Update `index.ts` to use proper imports instead of inline type imports
- Removes duplicate type definitions

## Test plan
- [x] All 86 unit tests pass
- [x] Lint passes

Fixes #92