### PR TITLE
feat: add typed addListener/removeListener methods to Devices

### DIFF
--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -372,6 +372,20 @@ export class Devices extends EventEmitter {
         return super.off(event, listener);
     }
 
+    addListener<K extends keyof DeviceEvents>(
+        event: K,
+        listener: DeviceEvents[K]
+    ): this {
+        return super.addListener(event, listener);
+    }
+
+    removeListener<K extends keyof DeviceEvents>(
+        event: K,
+        listener: DeviceEvents[K]
+    ): this {
+        return super.removeListener(event, listener);
+    }
+
     emit<K extends keyof DeviceEvents>(
         event: K,
         ...args: Parameters<DeviceEvents[K]>

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -339,6 +339,36 @@ describe('createTestSetup Helper', () => {
     });
 });
 
+describe('Devices addListener/removeListener (Issue #96)', () => {
+    it('addListener should register event handler', async () => {
+        const setup = createTestSetup();
+        const events: unknown[] = [];
+
+        setup.devices.addListener('reader-attached', (r: unknown) => events.push(r));
+        setup.devices.start();
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        assert.strictEqual(events.length, 1);
+        setup.devices.stop();
+    });
+
+    it('removeListener should unregister event handler', async () => {
+        const setup = createTestSetup();
+        const events: unknown[] = [];
+
+        const handler = (r: unknown) => events.push(r);
+        setup.devices.addListener('reader-attached', handler);
+        setup.devices.removeListener('reader-attached', handler);
+        setup.devices.start();
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        assert.strictEqual(events.length, 0, 'Handler should have been removed');
+        setup.devices.stop();
+    });
+});
+
 describe('MockDevices Integration', () => {
     it('should emit reader-attached events', async () => {
         const setup = createTestSetup({ readerName: 'ACR122U' });


### PR DESCRIPTION
## Summary
Add typed overloads for `addListener` and `removeListener` to match the existing `on`/`off` signatures for consistency and better type safety.

## Changes
- Add `addListener<K>()` typed method
- Add `removeListener<K>()` typed method
- Add 2 tests for the new methods

## Test plan
- [x] All 92 unit tests pass
- [x] Lint passes

Fixes #96