### PR TITLE
docs: fix getCards() return type in README to ReadonlyMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ class Devices extends EventEmitter {
     start(): void;
     stop(): void;
     listReaders(): Reader[];
-    getCards(): Map<string, Card>;      // Get all connected cards by reader name
+    getCards(): ReadonlyMap<string, Card>;  // Get all connected cards by reader name
     getCard(readerName: string): Card | null;  // Get card for specific reader
 
     on(event: 'reader-attached', listener: (reader: Reader) => void): this;


### PR DESCRIPTION
## Summary
Update the Devices API reference to reflect the correct return type after #101 changed it from `Map` to `ReadonlyMap`.

## Test plan
- [x] README renders correctly

Fixes #102