### PR TITLE
chore: bump version to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "smartcard",
-    "version": "3.5.0",
+    "version": "3.6.0",
     "description": "PC/SC bindings for Node.js using N-API - ABI stable across Node.js versions",
     "author": "Tom KP",
     "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps version from 3.5.0 to 3.6.0.

### Changes since 3.5.0:
- docs: Update README with getCards, getCard, transmitWithAutoResponse, control codes (#85)
- test: Add unit tests for parseFeatures() (#87)
- fix: Add explicit buffer bounds validation in parseFeatures() (#89)
- refactor: Extract isUnresponsiveCardError as pure function (#91)
- refactor: Consolidate addon type definitions (#93)
- test: Add createTestSetup helper to reduce boilerplate (#95)
- feat: Add typed addListener/removeListener methods (#97)
- refactor: Extract APDU building functions as pure utilities (#99)
- feat: Return ReadonlyMap from getCards() (#101)
- docs: Fix getCards() return type in README (#103)

## Test plan
- [ ] CI passes on all platforms