### PR TITLE
fix(reader_monitor): PnP event loss, dead context recovery, error codes, dangling szReader

### DIFF
--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -215,10 +215,36 @@ export class Devices extends EventEmitter {
                 this._handleCardRemoved(readerName);
                 break;
 
+            case 'monitor-recovered':
+                // The native monitor re-established its PC/SC context after a
+                // service restart; ours died with the same restart - replace it.
+                this._recreateContext();
+                break;
+
             case 'error':
                 // readerName contains error message for error events
                 this.emit('error', new Error(readerName));
                 break;
+        }
+    }
+
+    /**
+     * Replace the PC/SC context after the native monitor recovered from a
+     * service restart (the old handle is dead).
+     */
+    private _recreateContext(): void {
+        if (this._context) {
+            try {
+                this._context.close();
+            } catch {
+                // Dead context - nothing left to release
+            }
+        }
+        try {
+            this._context = new this._Context();
+        } catch (err) {
+            this._context = null;
+            this.emit('error', err instanceof Error ? err : new Error(String(err)));
         }
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -145,6 +145,7 @@ export interface MonitorEvent {
         | 'reader-detached'
         | 'card-inserted'
         | 'card-removed'
+        | 'monitor-recovered'
         | 'error';
     reader: string;
     state: number;

--- a/src/pcsc_errors.h
+++ b/src/pcsc_errors.h
@@ -40,6 +40,41 @@ inline const char* GetPCSCErrorString(LONG code) {
     if (ucode == SCARD_W_UNRESPONSIVE_CARD) return "Card is unresponsive";
     if (ucode == SCARD_W_UNSUPPORTED_CARD) return "Card is not supported";
 
+    // Extended mappings - numeric literals because macro availability differs
+    // between winscard.h and pcsc-lite while the code values are shared
+    // (MS SCARD error space). Note: 0x8010001F is SCARD_E_UNEXPECTED on
+    // Windows but SCARD_E_UNSUPPORTED_FEATURE on pcsc-lite.
+    if (ucode == 0x80100007) return "Waited too long";                        // SCARD_F_WAITED_TOO_LONG
+    if (ucode == 0x80100014) return "Unknown internal error";                 // SCARD_F_UNKNOWN_ERROR
+    if (ucode == 0x80100018) return "Service shutting down";                  // SCARD_P_SHUTDOWN
+    if (ucode == 0x8010001A) return "Reader unsupported";                     // SCARD_E_READER_UNSUPPORTED
+    if (ucode == 0x8010001B) return "Duplicate reader name";                  // SCARD_E_DUPLICATE_READER
+    if (ucode == 0x8010001C) return "Card unsupported";                       // SCARD_E_CARD_UNSUPPORTED
+    if (ucode == 0x8010001F) return "Unexpected error / unsupported feature"; // SCARD_E_UNEXPECTED (win) / SCARD_E_UNSUPPORTED_FEATURE (pcsc-lite)
+    if (ucode == 0x80100020) return "ICC installation error";                 // SCARD_E_ICC_INSTALLATION
+    if (ucode == 0x80100021) return "ICC create-order error";                 // SCARD_E_ICC_CREATEORDER
+    if (ucode == 0x80100022) return "Unsupported feature";                    // SCARD_E_UNSUPPORTED_FEATURE (win)
+    if (ucode == 0x80100023) return "Directory not found";                    // SCARD_E_DIR_NOT_FOUND
+    if (ucode == 0x80100024) return "File not found";                         // SCARD_E_FILE_NOT_FOUND
+    if (ucode == 0x80100025) return "No directory";                           // SCARD_E_NO_DIR
+    if (ucode == 0x80100026) return "No file";                                // SCARD_E_NO_FILE
+    if (ucode == 0x80100027) return "Access denied";                          // SCARD_E_NO_ACCESS
+    if (ucode == 0x80100028) return "Too many writes";                        // SCARD_E_WRITE_TOO_MANY
+    if (ucode == 0x80100029) return "Bad seek";                               // SCARD_E_BAD_SEEK
+    if (ucode == 0x8010002A) return "Invalid CHV/PIN";                        // SCARD_E_INVALID_CHV
+    if (ucode == 0x8010002B) return "Unknown resource manager";               // SCARD_E_UNKNOWN_RES_MNG
+    if (ucode == 0x8010002C) return "No such certificate";                    // SCARD_E_NO_SUCH_CERTIFICATE
+    if (ucode == 0x8010002D) return "Certificate unavailable";                // SCARD_E_CERTIFICATE_UNAVAILABLE
+    if (ucode == 0x8010002F) return "Communication data lost";                // SCARD_E_COMM_DATA_LOST
+    if (ucode == 0x80100030) return "No key container";                       // SCARD_E_NO_KEY_CONTAINER
+    if (ucode == 0x80100031) return "Server too busy";                        // SCARD_E_SERVER_TOO_BUSY
+    if (ucode == 0x8010006A) return "Security violation";                     // SCARD_W_SECURITY_VIOLATION
+    if (ucode == 0x8010006B) return "Wrong CHV/PIN";                          // SCARD_W_WRONG_CHV
+    if (ucode == 0x8010006C) return "CHV/PIN blocked";                        // SCARD_W_CHV_BLOCKED
+    if (ucode == 0x8010006D) return "End of file";                            // SCARD_W_EOF
+    if (ucode == 0x8010006E) return "Cancelled by user";                      // SCARD_W_CANCELLED_BY_USER
+    if (ucode == 0x8010006F) return "Card not authenticated";                 // SCARD_W_CARD_NOT_AUTHENTICATED
+
     return "Unknown PC/SC error";
 }
 

--- a/src/reader_monitor.cpp
+++ b/src/reader_monitor.cpp
@@ -57,8 +57,11 @@ ReaderMonitor::~ReaderMonitor() {
     // Ensure monitoring is stopped
     if (running_) {
         running_ = false;
-        if (contextValid_) {
-            SCardCancel(context_);
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (contextValid_) {
+                SCardCancel(context_);
+            }
         }
         if (monitorThread_.joinable()) {
             monitorThread_.join();
@@ -123,9 +126,14 @@ Napi::Value ReaderMonitor::Stop(const Napi::CallbackInfo& info) {
 
     running_ = false;
 
-    // Cancel any blocking SCardGetStatusChange call
-    if (contextValid_) {
-        SCardCancel(context_);
+    // Cancel any blocking SCardGetStatusChange call. mutex_ guards
+    // context_/contextValid_ against the recovery path swapping them
+    // on the monitor thread.
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (contextValid_) {
+            SCardCancel(context_);
+        }
     }
 
     // Wait for thread to finish
@@ -331,8 +339,9 @@ void ReaderMonitor::MonitorLoop() {
         }
 
         if (result != SCARD_S_SUCCESS) {
-            // Error - emit (with the numeric SCARD code) and continue
-            EmitEvent("error", FormatPCSCError(result), static_cast<DWORD>(result), {});
+            // Error - emit and continue. The numeric code rides in the
+            // message; state stays 0 so the field keeps its bitmask meaning.
+            EmitEvent("error", FormatPCSCError(result), 0, {});
 
             // Context-fatal errors (Smart Card service restart, dead handle):
             // the existing context will never recover, so retrying it forever
@@ -340,11 +349,16 @@ void ReaderMonitor::MonitorLoop() {
             // the next iteration. If re-establish fails, the next
             // SCardGetStatusChange on the zeroed handle fails fast and we
             // land back here - still one attempt per second.
+            // SCARD_E_INVALID_PARAMETER is deliberately not in this list: it
+            // is a per-call argument error, and recycling a healthy context
+            // would re-seed lastState and latch away pending transitions.
             DWORD ucode = static_cast<DWORD>(result);
             if (ucode == SCARD_E_SERVICE_STOPPED ||
                 ucode == SCARD_E_NO_SERVICE ||
-                ucode == SCARD_E_INVALID_HANDLE ||
-                ucode == SCARD_E_INVALID_PARAMETER) {
+                ucode == SCARD_E_INVALID_HANDLE) {
+                // mutex_ also guards context_/contextValid_ against Stop()
+                // and the destructor reading them for SCardCancel.
+                std::lock_guard<std::mutex> lock(mutex_);
                 if (contextValid_) {
                     SCardReleaseContext(context_);
                     contextValid_ = false;
@@ -354,12 +368,15 @@ void ReaderMonitor::MonitorLoop() {
                 LONG establishResult = SCardEstablishContext(SCARD_SCOPE_SYSTEM, nullptr, nullptr, &context_);
                 if (establishResult == SCARD_S_SUCCESS) {
                     contextValid_ = true;
-                    // Reader states were tracked against the dead context - rebuild
-                    std::lock_guard<std::mutex> lock(mutex_);
-                    UpdateReaderList();
+                    // Reader states were tracked against the dead context:
+                    // rebuild, emit whatever changed during the outage, and
+                    // tell the JS layer to refresh its own context.
+                    ResyncReaderList();
+                    EmitEvent("monitor-recovered", "", 0, {});
                 } else {
+                    // The error event above already fired this cycle - stay
+                    // at one error event per second while the service is down.
                     context_ = 0;
-                    EmitEvent("error", FormatPCSCError(establishResult), static_cast<DWORD>(establishResult), {});
                 }
             }
 
@@ -379,54 +396,7 @@ void ReaderMonitor::MonitorLoop() {
             // PnP notification - reader list changed
             if (readerNames[i] == "\\\\?PnP?\\Notification") {
                 pnpTriggered = true;
-                // Snapshot per-reader state BEFORE the update. UpdateReaderList()
-                // re-seeds lastState from a fresh SCARD_STATE_UNAWARE query, which
-                // silently latches any card transition that happened during the
-                // PnP churn - the pnpTriggered skip below means the transition
-                // would otherwise never be emitted (Issue #119).
-                std::unordered_map<std::string, DWORD> oldStates;
-                for (const auto& pair : readerStates_) {
-                    oldStates[pair.first] = pair.second.lastState;
-                }
-
-                // Update reader list (this rebuilds readerStates_ map)
-                UpdateReaderList();
-
-                // Find new readers
-                for (const auto& pair : readerStates_) {
-                    if (oldStates.find(pair.first) == oldStates.end()) {
-                        EmitEvent("reader-attached", pair.first, pair.second.lastState, pair.second.atr);
-                    }
-                }
-
-                // Find removed readers
-                for (const auto& pair : oldStates) {
-                    if (readerStates_.find(pair.first) == readerStates_.end()) {
-                        EmitEvent("reader-detached", pair.first, 0, {});
-                    }
-                }
-
-                // Surviving readers: compare the snapshot against the freshly
-                // seeded state and emit any card transition that would otherwise
-                // be latched away (same divergence pattern as the periodic
-                // refresh above).
-                for (const auto& pair : readerStates_) {
-                    auto oldIt = oldStates.find(pair.first);
-                    if (oldIt == oldStates.end()) {
-                        continue;  // New reader - already emitted reader-attached
-                    }
-
-                    bool wasPresent = (oldIt->second & SCARD_STATE_PRESENT) != 0;
-                    bool isPresent = (pair.second.lastState & SCARD_STATE_PRESENT) != 0;
-
-                    if (wasPresent != isPresent) {
-                        if (isPresent) {
-                            EmitEvent("card-inserted", pair.first, pair.second.lastState, pair.second.atr);
-                        } else {
-                            EmitEvent("card-removed", pair.first, pair.second.lastState, {});
-                        }
-                    }
-                }
+                ResyncReaderList();
                 continue;
             }
 
@@ -448,6 +418,46 @@ void ReaderMonitor::MonitorLoop() {
     }
 }
 
+// Rebuild readerStates_ and emit the difference: reader-attached/detached
+// for membership changes, card-inserted/removed for presence changes on
+// surviving readers. Needed because UpdateReaderList re-seeds lastState
+// from a fresh SCARD_STATE_UNAWARE query, which would otherwise silently
+// latch away any transition that happened since the last wait (PnP churn,
+// or a service outage the recovery path just healed). Caller holds mutex_.
+void ReaderMonitor::ResyncReaderList() {
+    std::unordered_map<std::string, DWORD> oldStates;
+    for (const auto& pair : readerStates_) {
+        oldStates[pair.first] = pair.second.lastState;
+    }
+
+    UpdateReaderList();
+
+    for (const auto& pair : readerStates_) {
+        if (oldStates.find(pair.first) == oldStates.end()) {
+            EmitEvent("reader-attached", pair.first, pair.second.lastState, pair.second.atr);
+        }
+    }
+
+    for (const auto& pair : oldStates) {
+        if (readerStates_.find(pair.first) == readerStates_.end()) {
+            EmitEvent("reader-detached", pair.first, 0, {});
+        }
+    }
+
+    for (const auto& pair : readerStates_) {
+        auto oldIt = oldStates.find(pair.first);
+        if (oldIt == oldStates.end()) {
+            continue;  // New reader - reader-attached already emitted
+        }
+        CardEvent event = DetectCardStateChange(oldIt->second, pair.second.lastState);
+        if (event == CardEvent::Inserted) {
+            EmitEvent("card-inserted", pair.first, pair.second.lastState, pair.second.atr);
+        } else if (event == CardEvent::Removed) {
+            EmitEvent("card-removed", pair.first, pair.second.lastState, {});
+        }
+    }
+}
+
 void ReaderMonitor::UpdateReaderList() {
     // Get reader list size
     DWORD readersLen = 0;
@@ -459,7 +469,6 @@ void ReaderMonitor::UpdateReaderList() {
     }
 
     if (result != SCARD_S_SUCCESS) {
-        EmitEvent("error", FormatPCSCError(result), static_cast<DWORD>(result), {});
         return;
     }
 
@@ -468,7 +477,6 @@ void ReaderMonitor::UpdateReaderList() {
     result = SCardListReaders(context_, nullptr, buffer.data(), &readersLen);
 
     if (result != SCARD_S_SUCCESS) {
-        EmitEvent("error", FormatPCSCError(result), static_cast<DWORD>(result), {});
         return;
     }
 
@@ -487,18 +495,35 @@ void ReaderMonitor::UpdateReaderList() {
         states[i].dwCurrentState = SCARD_STATE_UNAWARE;
     }
 
-    SCardGetStatusChange(context_, 0, states.data(), states.size());
+    LONG statusResult = SCardGetStatusChange(context_, 0, states.data(), states.size());
+    bool seeded = (statusResult == SCARD_S_SUCCESS);
 
     // Update reader states map (Issue #111 fix: use map keyed by name)
-    readerStates_.clear();
+    std::unordered_map<std::string, ReaderInfo> newStates;
     for (size_t i = 0; i < newNames.size(); i++) {
         ReaderInfo info;
-        info.lastState = states[i].dwEventState & ~SCARD_STATE_CHANGED;
-        if (states[i].cbAtr > 0) {
-            info.atr.assign(states[i].rgbAtr, states[i].rgbAtr + states[i].cbAtr);
+        info.lastState = SCARD_STATE_UNAWARE;
+        if (seeded) {
+            info.lastState = states[i].dwEventState & ~SCARD_STATE_CHANGED;
+            DWORD atrLen = states[i].cbAtr;
+            if (atrLen > sizeof(states[i].rgbAtr)) {
+                atrLen = sizeof(states[i].rgbAtr);
+            }
+            if (atrLen > 0) {
+                info.atr.assign(states[i].rgbAtr, states[i].rgbAtr + atrLen);
+            }
+        } else {
+            // Seed query failed: keep what we already knew about this reader
+            // instead of zeroing it - a zeroed lastState reads as a card
+            // removal to ResyncReaderList and as UNAWARE to the main wait.
+            auto existing = readerStates_.find(newNames[i]);
+            if (existing != readerStates_.end()) {
+                info = existing->second;
+            }
         }
-        readerStates_[newNames[i]] = info;
+        newStates[newNames[i]] = info;
     }
+    readerStates_ = std::move(newStates);
 }
 
 void ReaderMonitor::EmitEvent(const std::string& eventType, const std::string& readerName,

--- a/src/reader_monitor.cpp
+++ b/src/reader_monitor.cpp
@@ -1,5 +1,6 @@
 #include "reader_monitor.h"
 #include "pcsc_errors.h"
+#include <cstdio>
 #include <cstring>
 #include <unordered_map>
 #include <memory>
@@ -11,6 +12,14 @@ static_assert(PCSC_STATE_PRESENT == SCARD_STATE_PRESENT,
               "PCSC_STATE_PRESENT in reader_state_utils.h must match the platform SCARD_STATE_PRESENT");
 
 Napi::FunctionReference ReaderMonitor::constructor;
+
+// Format a PC/SC error as "message (0xXXXXXXXX)" so the numeric code
+// survives to JS even when only the message string is consumed.
+static std::string FormatPCSCError(LONG code) {
+    char hex[16];
+    std::snprintf(hex, sizeof(hex), " (0x%08X)", static_cast<unsigned int>(static_cast<DWORD>(code)));
+    return std::string(GetPCSCErrorString(code)) + hex;
+}
 
 // Number of iterations between forced full state refreshes (Windows reliability fix)
 static const int STATE_REFRESH_INTERVAL = 10;
@@ -204,9 +213,17 @@ void ReaderMonitor::MonitorLoop() {
             iterationCount = 0;
             std::lock_guard<std::mutex> lock(mutex_);
 
-            // Get fresh state for all readers
+            // Get fresh state for all readers.
+            // Reserve the final size BEFORE taking any c_str() pointers:
+            // szReader is captured while names are still being appended, and
+            // a later push_back that reallocates the vector moves the
+            // strings. Short names within SSO capacity (15 chars on MSVC,
+            // e.g. "ACS ACR122 0") live inline in the string object, so the
+            // previously taken pointers dangle and SCardGetStatusChange
+            // reads garbage (ERROR_INVALID_PARAMETER / lost events).
             std::vector<SCARD_READERSTATE> refreshStates;
             std::vector<std::string> refreshNames;
+            refreshNames.reserve(readerStates_.size());
 
             for (const auto& pair : readerStates_) {
                 refreshNames.push_back(pair.first);
@@ -236,6 +253,13 @@ void ReaderMonitor::MonitorLoop() {
             std::lock_guard<std::mutex> lock(mutex_);
             states.clear();
             readerNames.clear();
+
+            // Reserve for all tracked readers + the PnP entry so no
+            // push_back reallocates after szReader pointers are taken
+            // (SSO strings move with the vector - see the refresh block
+            // above). With a single reader the PnP push_back below is
+            // otherwise guaranteed to reallocate on the first iteration.
+            readerNames.reserve(readerStates_.size() + 1);
 
             // Add known readers - use the map for name-based lookup
             for (const auto& pair : readerStates_) {
@@ -276,9 +300,12 @@ void ReaderMonitor::MonitorLoop() {
                 continue;
             }
 
-            // Build fresh state query for all readers
+            // Build fresh state query for all readers.
+            // Reserve before taking c_str() pointers - see the refresh
+            // block above (SSO strings move on vector reallocation).
             std::vector<SCARD_READERSTATE> freshStates;
             std::vector<std::string> freshNames;
+            freshNames.reserve(readerStates_.size());
 
             for (const auto& pair : readerStates_) {
                 freshNames.push_back(pair.first);
@@ -304,8 +331,38 @@ void ReaderMonitor::MonitorLoop() {
         }
 
         if (result != SCARD_S_SUCCESS) {
-            // Error - emit and continue
-            EmitEvent("error", GetPCSCErrorString(result), 0, {});
+            // Error - emit (with the numeric SCARD code) and continue
+            EmitEvent("error", FormatPCSCError(result), static_cast<DWORD>(result), {});
+
+            // Context-fatal errors (Smart Card service restart, dead handle):
+            // the existing context will never recover, so retrying it forever
+            // is pointless (Issue #119). Release it and re-establish before
+            // the next iteration. If re-establish fails, the next
+            // SCardGetStatusChange on the zeroed handle fails fast and we
+            // land back here - still one attempt per second.
+            DWORD ucode = static_cast<DWORD>(result);
+            if (ucode == SCARD_E_SERVICE_STOPPED ||
+                ucode == SCARD_E_NO_SERVICE ||
+                ucode == SCARD_E_INVALID_HANDLE ||
+                ucode == SCARD_E_INVALID_PARAMETER) {
+                if (contextValid_) {
+                    SCardReleaseContext(context_);
+                    contextValid_ = false;
+                }
+                context_ = 0;
+
+                LONG establishResult = SCardEstablishContext(SCARD_SCOPE_SYSTEM, nullptr, nullptr, &context_);
+                if (establishResult == SCARD_S_SUCCESS) {
+                    contextValid_ = true;
+                    // Reader states were tracked against the dead context - rebuild
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    UpdateReaderList();
+                } else {
+                    context_ = 0;
+                    EmitEvent("error", FormatPCSCError(establishResult), static_cast<DWORD>(establishResult), {});
+                }
+            }
+
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
             continue;
         }
@@ -322,10 +379,14 @@ void ReaderMonitor::MonitorLoop() {
             // PnP notification - reader list changed
             if (readerNames[i] == "\\\\?PnP?\\Notification") {
                 pnpTriggered = true;
-                // Get old reader names
-                std::vector<std::string> oldNames;
+                // Snapshot per-reader state BEFORE the update. UpdateReaderList()
+                // re-seeds lastState from a fresh SCARD_STATE_UNAWARE query, which
+                // silently latches any card transition that happened during the
+                // PnP churn - the pnpTriggered skip below means the transition
+                // would otherwise never be emitted (Issue #119).
+                std::unordered_map<std::string, DWORD> oldStates;
                 for (const auto& pair : readerStates_) {
-                    oldNames.push_back(pair.first);
+                    oldStates[pair.first] = pair.second.lastState;
                 }
 
                 // Update reader list (this rebuilds readerStates_ map)
@@ -333,22 +394,37 @@ void ReaderMonitor::MonitorLoop() {
 
                 // Find new readers
                 for (const auto& pair : readerStates_) {
-                    bool found = false;
-                    for (const auto& old : oldNames) {
-                        if (old == pair.first) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
+                    if (oldStates.find(pair.first) == oldStates.end()) {
                         EmitEvent("reader-attached", pair.first, pair.second.lastState, pair.second.atr);
                     }
                 }
 
                 // Find removed readers
-                for (const auto& old : oldNames) {
-                    if (readerStates_.find(old) == readerStates_.end()) {
-                        EmitEvent("reader-detached", old, 0, {});
+                for (const auto& pair : oldStates) {
+                    if (readerStates_.find(pair.first) == readerStates_.end()) {
+                        EmitEvent("reader-detached", pair.first, 0, {});
+                    }
+                }
+
+                // Surviving readers: compare the snapshot against the freshly
+                // seeded state and emit any card transition that would otherwise
+                // be latched away (same divergence pattern as the periodic
+                // refresh above).
+                for (const auto& pair : readerStates_) {
+                    auto oldIt = oldStates.find(pair.first);
+                    if (oldIt == oldStates.end()) {
+                        continue;  // New reader - already emitted reader-attached
+                    }
+
+                    bool wasPresent = (oldIt->second & SCARD_STATE_PRESENT) != 0;
+                    bool isPresent = (pair.second.lastState & SCARD_STATE_PRESENT) != 0;
+
+                    if (wasPresent != isPresent) {
+                        if (isPresent) {
+                            EmitEvent("card-inserted", pair.first, pair.second.lastState, pair.second.atr);
+                        } else {
+                            EmitEvent("card-removed", pair.first, pair.second.lastState, {});
+                        }
                     }
                 }
                 continue;
@@ -383,6 +459,7 @@ void ReaderMonitor::UpdateReaderList() {
     }
 
     if (result != SCARD_S_SUCCESS) {
+        EmitEvent("error", FormatPCSCError(result), static_cast<DWORD>(result), {});
         return;
     }
 
@@ -391,6 +468,7 @@ void ReaderMonitor::UpdateReaderList() {
     result = SCardListReaders(context_, nullptr, buffer.data(), &readersLen);
 
     if (result != SCARD_S_SUCCESS) {
+        EmitEvent("error", FormatPCSCError(result), static_cast<DWORD>(result), {});
         return;
     }
 

--- a/src/reader_monitor.h
+++ b/src/reader_monitor.h
@@ -55,6 +55,7 @@ private:
     // Internal methods
     void MonitorLoop();
     void UpdateReaderList();
+    void ResyncReaderList();
     void EmitEvent(const std::string& eventType, const std::string& readerName,
                    DWORD state, const std::vector<uint8_t>& atr);
     void ApplyCardStateChange(ReaderInfo& info, const std::string& readerName,


### PR DESCRIPTION
Four reliability fixes for the `ReaderMonitor` status change loop. All were found and field verified while debugging intermittent Windows card read failures (roughly 1 tap in 10 registering) in a production Electron access control deployment, running readers under both the Windows inbox CCID driver and the ACS vendor driver.

Relates to #111 (missed card events) and #119 (native side validation of the state tracking). Fix 4 has no existing issue but is likely the root cause behind several "no events on Windows" reports.

## Fix 1: PnP churn silently swallows card events

When the `\\?PnP?\Notification` entry reports CHANGED, `UpdateReaderList()` reseeds every known reader's `lastState` from a fresh `SCARD_STATE_UNAWARE` query. A card tapped on a surviving reader during the same wake up is already PRESENT in that fresh query, so the transition is latched without ever emitting `card-inserted`. The `if (pnpTriggered) { continue; }` skip then means the per reader entries in the same batch are not processed either. The comment claiming the next iteration will catch it is unfortunately wrong: the latched state removes the edge, so nothing is ever emitted. The observable symptom is an orphan `card-removed` with no matching insert whenever a tap coincides with PnP activity, and USB reenumeration is by definition PnP activity.

The fix snapshots per reader `lastState` before the rebuild, compares presence bits after it, and emits the missed transitions. This is the same divergence emitting pattern the periodic refresh block already uses. The snapshot map also replaces the quadratic `oldNames` scans.

## Fix 2: a dead PC/SC context is retried forever

On `SCardGetStatusChange` failure the loop emitted `error`, slept one second, and retried the same context indefinitely. After a Smart Card service restart (a driver install does this) the handle can never recover, so the monitor wedges permanently while appearing alive.

The fix classifies `SCARD_E_SERVICE_STOPPED`, `SCARD_E_NO_SERVICE`, `SCARD_E_INVALID_HANDLE` and `SCARD_E_INVALID_PARAMETER` as fatal to the context, then releases it, calls `SCardEstablishContext` again and rebuilds the reader list. If reestablishment fails the handle is zeroed so the next call fails fast, preserving the existing one attempt per second cadence with no new spin. `UpdateReaderList()` previously swallowed `SCardListReaders` failures with bare returns; those paths now emit `error` events.

## Fix 3: error events discard the error code

All error emissions passed 0 as the event's `state` param and relied on a partial string table, so real driver conditions surfaced as "Unknown PC/SC error" with no code. A field example: the inbox CCID driver deterministically produced Win32 `ERROR_INVALID_PARAMETER` (87), see Fix 4, which was unmappable and undiagnosable. Errors now carry the numeric code in the `state` param and formatted as hex in the message, and `GetPCSCErrorString` covers the full standard SCARD code set.

## Fix 4: dangling `szReader` pointers when reader names fit in SSO

Three sites used this pattern:

```cpp
readerNames.push_back(name);
state.szReader = readerNames.back().c_str();
```

A later `push_back` can reallocate the `vector<std::string>`. Strings within SSO capacity (15 chars on MSVC) store their buffer inline, so the captured `c_str()` pointer dangles after the move. The Windows inbox CCID driver names the ACR122U `ACS ACR122 0`, which is 12 characters, and with a single tracked reader the loop top build reallocates deterministically when the PnP entry is pushed, handing `SCardGetStatusChange` a pointer into freed memory on the very first iteration. The field manifestation was one `ERROR_INVALID_PARAMETER` right after attach, then a monitor blocked on garbage state that never reports card transitions. Vendor driver names (`ACS ACR122U PICC Interface 0`, 28 characters) are heap allocated and unaffected, which made driver choice look like the culprit for a long time. The fix reserves the final (knowable) capacity before any pointer is captured, at all three sites.

## Testing

Compiles clean on MSVC (windows-2022, Electron 41 headers) and clang (macOS arm64) with no new warnings. All monitor loop changes run on the monitor thread, so no new locking is needed; the only cross thread interaction, `SCardCancel` from `Stop()`, tolerates a mid swap handle harmlessly. The changes have been deployed to a production fleet as a package patch: the PnP fix eliminated orphan `card-removed` events, the context reestablishment survives Smart Card service restarts, and the SSO fix removed the deterministic attach time error 87 on inbox CCID machines, all verified before and after in structured logs.

Happy to split this into separate PRs if preferred.
