### PR TITLE
fix: correct inverted PCSC_STATE_PRESENT constant

### DIFF
--- a/src/reader_monitor.cpp
+++ b/src/reader_monitor.cpp
@@ -5,6 +5,11 @@
 #include <memory>
 #include "reader_state_utils.h"
 
+// reader_state_utils.h avoids including the PC/SC headers so it stays testable
+// in isolation; this pins its mirrored constant to the platform's value.
+static_assert(PCSC_STATE_PRESENT == SCARD_STATE_PRESENT,
+              "PCSC_STATE_PRESENT in reader_state_utils.h must match the platform SCARD_STATE_PRESENT");
+
 Napi::FunctionReference ReaderMonitor::constructor;
 
 // Number of iterations between forced full state refreshes (Windows reliability fix)

--- a/src/reader_state_utils.h
+++ b/src/reader_state_utils.h
@@ -4,7 +4,7 @@
 
 enum class CardEvent { None, Inserted, Removed };
 
-constexpr uint32_t PCSC_STATE_PRESENT = 0x00000010;
+constexpr uint32_t PCSC_STATE_PRESENT = 0x00000020;
 
 inline CardEvent DetectCardStateChange(uint32_t oldState, uint32_t newState) {
     bool wasPresent = (oldState & PCSC_STATE_PRESENT) != 0;

--- a/src/test/reader_state_utils_test.cpp
+++ b/src/test/reader_state_utils_test.cpp
@@ -2,13 +2,19 @@
 #include "catch.hpp"
 #include "reader_state_utils.h"
 
+TEST_CASE("PCSC_STATE_PRESENT matches the PC/SC SCARD_STATE_PRESENT value", "[state]") {
+    // Pinned to the literal so a typo in the constant fails here instead of
+    // silently inverting every card event.
+    REQUIRE(PCSC_STATE_PRESENT == 0x00000020);
+}
+
 TEST_CASE("DetectCardStateChange", "[state]") {
     SECTION("returns Inserted when card becomes present") {
-        REQUIRE(DetectCardStateChange(0x00, PCSC_STATE_PRESENT) == CardEvent::Inserted);
+        REQUIRE(DetectCardStateChange(0x00, 0x00000020) == CardEvent::Inserted);
     }
 
     SECTION("returns Removed when card becomes absent") {
-        REQUIRE(DetectCardStateChange(PCSC_STATE_PRESENT, 0x00) == CardEvent::Removed);
+        REQUIRE(DetectCardStateChange(0x00000020, 0x00) == CardEvent::Removed);
     }
 
     SECTION("returns None when state unchanged - no card") {


### PR DESCRIPTION
## Summary

Fixes a critical regression in #120: `PCSC_STATE_PRESENT` in `src/reader_state_utils.h` was defined as `0x10`, which is actually `SCARD_STATE_EMPTY`. The real `SCARD_STATE_PRESENT` is `0x20`. As a result `DetectCardStateChange` inverted every card event — insertions emitted `card-removed` and removals emitted `card-inserted`, and `lib/devices.ts` attempted to connect to empty slots. Verified by compiling the helper against the real PC/SC header: `EMPTY (0x12) → PRESENT|INUSE (0x122)` returned `CardEvent::Removed`.

CI stayed green because the tests compared the helper's output against the same (wrong) symbol, so they passed for any value of the constant.

## Changes

- `src/reader_state_utils.h`: set `PCSC_STATE_PRESENT` to `0x00000020`, matching the platform macro, `mock.ts:362`, and `addon.cpp:34`
- `src/reader_monitor.cpp`: `static_assert(PCSC_STATE_PRESENT == SCARD_STATE_PRESENT)` — the header stays PC/SC-free for testability, but any future drift from the platform value is now a compile error
- `src/test/reader_state_utils_test.cpp`: new test case pinning the constant to the `0x20` literal, and the Inserted/Removed assertions now use the literal instead of the symbol, so the suite fails if the constant is ever wrong again

## Testing

- `smartcard_tests`: all 7 assertions in 2 test cases pass (and fail if the constant is reverted)
- `npm test`: 106/106 pass
- addon + static_assert compile clean on macOS