### PR TITLE
fix: clearer missing-addon error, document card reset / bun / containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,20 @@ interface Card {
 }
 ```
 
+Reset a card in place with `reconnect` — no physical removal needed:
+
+```javascript
+const { SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0, SCARD_PROTOCOL_T1, SCARD_RESET_CARD, SCARD_UNPOWER_CARD } = require('smartcard');
+
+// Warm reset
+await card.reconnect(SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1, SCARD_RESET_CARD);
+
+// Cold reset (power off, then power back on)
+await card.reconnect(SCARD_SHARE_SHARED, SCARD_PROTOCOL_T0 | SCARD_PROTOCOL_T1, SCARD_UNPOWER_CARD);
+```
+
+`disconnect(disposition)` accepts the same constants to reset or unpower the card on the way out.
+
 ### Devices
 
 High-level event-driven API.
@@ -456,6 +470,30 @@ try {
 
 ### Build errors on Linux
 - Install development headers: `sudo apt-get install libpcsclite-dev`
+
+### "Could not resolve: ../../build/Release/smartcard_napi.node"
+The native addon is compiled by `node-gyp` during `npm install`. If the file is missing:
+- **Bun**: install scripts are skipped for untrusted packages — add `"trustedDependencies": ["smartcard"]` to your package.json and reinstall
+- **Bundlers** (esbuild, webpack, electrobun): native addons can't be bundled — mark `smartcard` as external so the require happens at runtime
+- Rebuild manually: `npm rebuild smartcard`
+
+### Docker & containers
+The library talks to the PC/SC daemon. Either mount the host daemon's socket:
+
+```dockerfile
+# In the image (libpcsclite-dev is needed at npm install time to build the addon)
+RUN apt-get install -y libpcsclite1
+```
+
+```bash
+docker run -v /var/run/pcscd:/var/run/pcscd myapp
+```
+
+Or run `pcscd` inside the container with USB passthrough:
+
+```bash
+docker run --privileged -v /dev/bus/usb:/dev/bus/usb myapp
+```
 
 ## Migrating from v1.x
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,7 +5,18 @@ import type {
 } from './types';
 
 // Load native addon
-const addon = require('../../build/Release/smartcard_napi.node') as NativeAddon;
+let addon: NativeAddon;
+try {
+    addon = require('../../build/Release/smartcard_napi.node') as NativeAddon;
+} catch (err) {
+    throw new Error(
+        'smartcard: native addon not found at build/Release/smartcard_napi.node. ' +
+        'The addon is compiled by node-gyp during npm install. If your package manager ' +
+        'skips install scripts (bun requires "trustedDependencies": ["smartcard"]), or you ' +
+        'are bundling (mark smartcard as external), rebuild with: npm rebuild smartcard. ' +
+        `Original error: ${err instanceof Error ? err.message : String(err)}`
+    );
+}
 
 // Re-export native classes
 export const Context = addon.Context as ContextConstructor;


### PR DESCRIPTION
## Problem

- Bun users hit a raw `Could not resolve: ../../build/Release/smartcard_napi.node` with no hint that install scripts were skipped or that bundlers need the module marked external (#123)
- Programmatic card reset via `reconnect` is fully supported but undocumented (#127)
- The container setup from #9 only lives in an issue comment

## Changes

- `lib/index.ts`: wrap the addon require and rethrow with an actionable message (trustedDependencies / external / `npm rebuild smartcard`)
- README: warm/cold reset example under Card, plus Troubleshooting sections for the missing-addon error and Docker/containers

Closes #123