### PR TITLE
fix: compiler warnings (extracted from #117)

### DIFF
--- a/src/async_workers.cpp
+++ b/src/async_workers.cpp
@@ -60,10 +60,10 @@ void WaitForChangeWorker::OnOK() {
         }
 
         deferred_.Resolve(changes);
-    } else if (result_ == SCARD_E_CANCELLED) {
+    } else if (result_ == static_cast<LONG>(SCARD_E_CANCELLED)) {
         // Cancelled - resolve with null
         deferred_.Resolve(env.Null());
-    } else if (result_ == SCARD_E_TIMEOUT) {
+    } else if (result_ == static_cast<LONG>(SCARD_E_TIMEOUT)) {
         // Timeout - resolve with empty array
         deferred_.Resolve(Napi::Array::New(env, 0));
     } else {

--- a/src/pcsc_context.cpp
+++ b/src/pcsc_context.cpp
@@ -62,7 +62,7 @@ Napi::Value PCSCContext::ListReaders(const Napi::CallbackInfo& info) {
     DWORD readersLen = 0;
     LONG result = SCardListReaders(context_, nullptr, nullptr, &readersLen);
 
-    if (result == SCARD_E_NO_READERS_AVAILABLE) {
+    if (result == static_cast<LONG>(SCARD_E_NO_READERS_AVAILABLE)) {
         // No readers - return empty array
         return Napi::Array::New(env, 0);
     }
@@ -164,7 +164,7 @@ Napi::Value PCSCContext::WaitForChange(const Napi::CallbackInfo& info) {
         DWORD readersLen = 0;
         LONG result = SCardListReaders(context_, nullptr, nullptr, &readersLen);
 
-        if (result == SCARD_E_NO_READERS_AVAILABLE) {
+        if (result == static_cast<LONG>(SCARD_E_NO_READERS_AVAILABLE)) {
             // Add PnP notification to detect when readers are attached
             readerNames.push_back("\\\\?PnP?\\Notification");
             currentStates.push_back(SCARD_STATE_UNAWARE);
@@ -200,7 +200,7 @@ Napi::Value PCSCContext::Cancel(const Napi::CallbackInfo& info) {
     }
 
     LONG result = SCardCancel(context_);
-    if (result != SCARD_S_SUCCESS && result != SCARD_E_INVALID_HANDLE) {
+    if (result != SCARD_S_SUCCESS && result != static_cast<LONG>(SCARD_E_INVALID_HANDLE)) {
         Napi::Error::New(env, GetPCSCErrorString(result)).ThrowAsJavaScriptException();
     }
 

--- a/src/reader_monitor.cpp
+++ b/src/reader_monitor.cpp
@@ -261,11 +261,11 @@ void ReaderMonitor::MonitorLoop() {
             break;
         }
 
-        if (result == SCARD_E_CANCELLED) {
+        if (result == static_cast<LONG>(SCARD_E_CANCELLED)) {
             break;
         }
 
-        if (result == SCARD_E_TIMEOUT) {
+        if (result == static_cast<LONG>(SCARD_E_TIMEOUT)) {
             // Timeout - query fresh state to detect missed events (Issue #111)
             // On Windows, dwEventState after timeout may just mirror dwCurrentState
             // rather than reflecting actual hardware state. We must explicitly
@@ -377,7 +377,7 @@ void ReaderMonitor::UpdateReaderList() {
     DWORD readersLen = 0;
     LONG result = SCardListReaders(context_, nullptr, nullptr, &readersLen);
 
-    if (result == SCARD_E_NO_READERS_AVAILABLE || readersLen == 0) {
+    if (result == static_cast<LONG>(SCARD_E_NO_READERS_AVAILABLE) || readersLen == 0) {
         readerStates_.clear();
         return;
     }


### PR DESCRIPTION
The verified-correct part of #117, cherry-picked with authorship preserved: `static_cast<LONG>` on the SCARD constant comparisons in `async_workers.cpp`, `pcsc_context.cpp`, and `reader_monitor.cpp`.

Local build goes from 3 sign-compare warnings to 0; all tests pass.

Credit: @liamcmitchell