### PR TITLE
fix: retry lagging reader lookups, harden the event queue

### DIFF
--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -50,6 +50,7 @@ export class Devices extends EventEmitter {
     private _running = false;
     private _readers = new Map<string, ReaderStateInternal>();
     private _eventQueue: Promise<void> = Promise.resolve();
+    private _generation = 0;
 
     // Dependencies (can be injected for testing)
     private _Context: ContextConstructor;
@@ -89,6 +90,9 @@ export class Devices extends EventEmitter {
             // Create context for card connections
             this._context = new this._Context();
 
+            // A rejected queue from a previous session must not block this one
+            this._eventQueue = Promise.resolve();
+
             // Create native monitor
             this._monitor = new this._ReaderMonitor();
             this._running = true;
@@ -107,6 +111,9 @@ export class Devices extends EventEmitter {
      */
     stop(): void {
         this._running = false;
+        // Invalidate in-flight handlers parked on an await: a handler that
+        // resumes after this stop (or a later restart) must not touch state
+        this._generation++;
 
         if (this._monitor) {
             try {
@@ -182,10 +189,26 @@ export class Devices extends EventEmitter {
      * Queues events to prevent race conditions when multiple events arrive concurrently
      */
     private _handleEvent(event: MonitorEvent): void {
-        // Chain this event onto the queue to serialize processing
-        this._eventQueue = this._eventQueue.then(() =>
-            this._processEvent(event)
-        );
+        // Chain this event onto the queue to serialize processing. The catch
+        // keeps the chain alive: a rejected link would otherwise silently
+        // stop all future event processing.
+        this._eventQueue = this._eventQueue
+            .then(() => this._processEvent(event))
+            .catch((err) => this._safeEmitError(err));
+    }
+
+    /**
+     * Emit an error without killing the event pump: with no 'error' listener
+     * EventEmitter throws, which would reject the event queue and stop all
+     * future event processing.
+     */
+    private _safeEmitError(err: unknown): void {
+        if (this.listenerCount('error') > 0) {
+            this.emit(
+                'error',
+                err instanceof Error ? err : new Error(String(err))
+            );
+        }
     }
 
     /**
@@ -310,42 +333,77 @@ export class Devices extends EventEmitter {
 
         state.hasCard = true;
 
+        const generation = this._generation;
+
         // Try to connect to the card
         try {
-            const readers = this._context!.listReaders();
-            const reader = readers.find((r) => r.name === readerName);
-
-            if (reader) {
-                let nativeCard: Card;
-                try {
-                    // First try with both T=0 and T=1 protocols
-                    nativeCard = await reader.connect(
-                        this._SCARD_SHARE_SHARED,
-                        this._SCARD_PROTOCOL_T0 | this._SCARD_PROTOCOL_T1
-                    );
-                } catch (dualProtocolErr) {
-                    // If dual protocol fails with unresponsive card error,
-                    // fallback to T=0 only (issue #34)
-                    if (isUnresponsiveCardError(dualProtocolErr as Error)) {
-                        nativeCard = await reader.connect(
-                            this._SCARD_SHARE_SHARED,
-                            this._SCARD_PROTOCOL_T0
-                        );
-                    } else {
-                        // Re-throw if it's a different error
-                        throw dualProtocolErr;
+            // The reader list can lag the monitor event during PnP churn -
+            // retry briefly before giving up (Issue #117)
+            let reader: Reader | undefined;
+            for (let attempt = 0; attempt < 3; attempt++) {
+                if (attempt > 0) {
+                    await new Promise((resolve) => setTimeout(resolve, 50));
+                    // Bail if monitoring stopped or restarted while we slept
+                    if (!this._running || this._generation !== generation) {
+                        return;
                     }
                 }
-
-                // Wrap the native card to add autoGetResponse support
-                const card = wrapCard(nativeCard);
-                state.card = card;
-
-                this.emit('card-inserted', {
-                    reader: { name: readerName, state: eventState, atr: atr },
-                    card: card,
-                });
+                const readers = this._context
+                    ? this._context.listReaders()
+                    : [];
+                reader = readers.find((r) => r.name === readerName);
+                if (reader) {
+                    break;
+                }
             }
+
+            if (!reader) {
+                // Reader vanished mid-churn: leave no half-state behind - the
+                // queued reader-detached will finish the cleanup
+                state.hasCard = false;
+                return;
+            }
+
+            let nativeCard: Card;
+            try {
+                // First try with both T=0 and T=1 protocols
+                nativeCard = await reader.connect(
+                    this._SCARD_SHARE_SHARED,
+                    this._SCARD_PROTOCOL_T0 | this._SCARD_PROTOCOL_T1
+                );
+            } catch (dualProtocolErr) {
+                // If dual protocol fails with unresponsive card error,
+                // fallback to T=0 only (issue #34)
+                if (isUnresponsiveCardError(dualProtocolErr as Error)) {
+                    nativeCard = await reader.connect(
+                        this._SCARD_SHARE_SHARED,
+                        this._SCARD_PROTOCOL_T0
+                    );
+                } else {
+                    // Re-throw if it's a different error
+                    throw dualProtocolErr;
+                }
+            }
+
+            if (!this._running || this._generation !== generation) {
+                // stop() ran while connect was in flight - it cannot see this
+                // card, so release the handle here
+                try {
+                    nativeCard.disconnect();
+                } catch {
+                    // Ignore disconnect errors
+                }
+                return;
+            }
+
+            // Wrap the native card to add autoGetResponse support
+            const card = wrapCard(nativeCard);
+            state.card = card;
+
+            this.emit('card-inserted', {
+                reader: { name: readerName, state: eventState, atr: atr },
+                card: card,
+            });
         } catch (err) {
             // Emit error but don't fail
             this.emit('error', err as Error);

--- a/test/helpers/mock.ts
+++ b/test/helpers/mock.ts
@@ -337,6 +337,12 @@ export class MockReaderMonitor implements ReaderMonitor {
             }
         }
     }
+
+    emitError(message: string): void {
+        if (this._running) {
+            this._emitEvent('error', message, 0, null);
+        }
+    }
 }
 
 interface MockAddon {

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -2036,3 +2036,98 @@ describe('Windows Card Event State Tracking (Issue #111)', () => {
         devices.stop();
     });
 });
+
+describe('Insertion retry and event queue resilience (Issue #117)', () => {
+    it('should retry the reader lookup when the list lags the event', async () => {
+        const mockCard = new MockCard(1, Buffer.from([0x3b]));
+        const mockReader = new MockReader('ACR122U');
+        const mockContext = new MockContext();
+        const mockMonitor = new MockReaderMonitor();
+
+        mockContext.addReader(mockReader);
+        mockMonitor.attachReader(mockReader);
+
+        // Reader list lags the monitor event: empty on the first call after
+        // insertion, populated afterwards
+        let lagging = false;
+        const realListReaders = mockContext.listReaders.bind(mockContext);
+        mockContext.listReaders = () => {
+            if (lagging) {
+                lagging = false;
+                return [];
+            }
+            return realListReaders();
+        };
+
+        const MockDevices = createMockDevices({
+            Context: function () {
+                return mockContext;
+            } as unknown as new () => MockContext,
+            ReaderMonitor: function () {
+                return mockMonitor;
+            } as unknown as new () => MockReaderMonitor,
+        });
+
+        const devices = new MockDevices();
+        const events: { reader: ReaderEventInfo; card: Card }[] = [];
+        devices.on(
+            'card-inserted',
+            (event: { reader: ReaderEventInfo; card: Card }) =>
+                events.push(event)
+        );
+
+        devices.start();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        lagging = true;
+        mockMonitor.insertCard('ACR122U', mockCard);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        assert.strictEqual(events.length, 1);
+        assert.strictEqual(events[0].reader.name, 'ACR122U');
+        assert(events[0].card);
+
+        devices.stop();
+    });
+
+    it('should keep processing events after an error event with no error listener', async () => {
+        const mockCard = new MockCard(1, Buffer.from([0x3b]));
+        const mockReader = new MockReader('ACR122U');
+        const mockContext = new MockContext();
+        const mockMonitor = new MockReaderMonitor();
+
+        mockContext.addReader(mockReader);
+        mockMonitor.attachReader(mockReader);
+
+        const MockDevices = createMockDevices({
+            Context: function () {
+                return mockContext;
+            } as unknown as new () => MockContext,
+            ReaderMonitor: function () {
+                return mockMonitor;
+            } as unknown as new () => MockReaderMonitor,
+        });
+
+        // Deliberately no 'error' listener: the emit throws inside the
+        // queue, which previously poisoned it and stopped all later events
+        const devices = new MockDevices();
+        const events: { reader: ReaderEventInfo; card: Card }[] = [];
+        devices.on(
+            'card-inserted',
+            (event: { reader: ReaderEventInfo; card: Card }) =>
+                events.push(event)
+        );
+
+        devices.start();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        mockMonitor.emitError('Service not available (0x8010001D)');
+        mockMonitor.insertCard('ACR122U', mockCard);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        assert.strictEqual(events.length, 1);
+        assert.strictEqual(events[0].reader.name, 'ACR122U');
+
+        devices.stop();
+    });
+});


### PR DESCRIPTION
## Problem

Two related reliability gaps in `lib/devices.ts`, both surfaced while reviewing #117 (which targeted the first one):

- During PnP churn the reader list can lag a `card-inserted` event: `listReaders()` misses the reader, the handler silently does nothing, and `{hasCard: true, card: null}` is left behind — no `card-inserted` ever fires because the native side already latched PRESENT.
- The serialized `_eventQueue` had no rejection handling: one throw (e.g. an `'error'` emit with no listener registered) rejected the chain and permanently stopped all event processing, unrecoverable even by `stop()`/`start()`.

## Changes

- Insertion handler retries the lookup (3 attempts, 50ms apart), re-checks `_running` and a generation counter after every await — a handler resuming after `stop()` bails, and one that already connected releases the handle instead of leaking it. When the reader is truly gone, `hasCard` is reset so no half-state survives.
- `_eventQueue` gets a `.catch` that re-emits via a listener-aware helper (no listener → swallowed rather than killing the pump), and `start()` resets the queue.

Implements what #117 was after, minus the crash paths flagged in review there.

## Testing

- New: reader list lags the event → `card-inserted` still emitted after retry
- New: error event with no `'error'` listener → later events still processed
- Full suite: 121 tests pass, typecheck and lint clean