### PR TITLE
refactor: parameterize the present mask, namespace the shipped header

### DIFF
--- a/src/reader_monitor.cpp
+++ b/src/reader_monitor.cpp
@@ -6,10 +6,8 @@
 #include <memory>
 #include "reader_state_utils.h"
 
-// reader_state_utils.h avoids including the PC/SC headers so it stays testable
-// in isolation; this pins its mirrored constant to the platform's value.
-static_assert(PCSC_STATE_PRESENT == SCARD_STATE_PRESENT,
-              "PCSC_STATE_PRESENT in reader_state_utils.h must match the platform SCARD_STATE_PRESENT");
+using smartcard::CardEvent;
+using smartcard::DetectCardStateChange;
 
 Napi::FunctionReference ReaderMonitor::constructor;
 
@@ -184,7 +182,7 @@ Napi::Value ReaderMonitor::GetIsRunning(const Napi::CallbackInfo& info) {
 void ReaderMonitor::ApplyCardStateChange(ReaderInfo& info, const std::string& readerName,
                                          const SCARD_READERSTATE& readerState) {
     DWORD newState = readerState.dwEventState & ~SCARD_STATE_CHANGED;
-    CardEvent event = DetectCardStateChange(info.lastState, newState);
+    CardEvent event = DetectCardStateChange(info.lastState, newState, SCARD_STATE_PRESENT);
 
     // Commit so a stale lastState can't make the next SCardGetStatusChange
     // re-report the same change - but never store SCARD_STATE_IGNORE (fed
@@ -428,7 +426,7 @@ void ReaderMonitor::ResyncReaderList() {
         if (oldIt == oldStates.end()) {
             continue;  // New reader - reader-attached already emitted
         }
-        CardEvent event = DetectCardStateChange(oldIt->second, pair.second.lastState);
+        CardEvent event = DetectCardStateChange(oldIt->second, pair.second.lastState, SCARD_STATE_PRESENT);
         if (event == CardEvent::Inserted) {
             EmitEvent("card-inserted", pair.first, pair.second.lastState, pair.second.atr);
         } else if (event == CardEvent::Removed) {

--- a/src/reader_state_utils.h
+++ b/src/reader_state_utils.h
@@ -2,15 +2,23 @@
 #pragma once
 #include <cstdint>
 
+namespace smartcard {
+
 enum class CardEvent { None, Inserted, Removed };
 
-constexpr uint32_t PCSC_STATE_PRESENT = 0x00000020;
-
-inline CardEvent DetectCardStateChange(uint32_t oldState, uint32_t newState) {
-    bool wasPresent = (oldState & PCSC_STATE_PRESENT) != 0;
-    bool isPresent = (newState & PCSC_STATE_PRESENT) != 0;
+// presentMask is the platform's SCARD_STATE_PRESENT bit, passed in by the
+// caller. This header deliberately includes no PC/SC headers so the logic is
+// testable in isolation - receiving the mask instead of mirroring its value
+// means there is no hand-typed copy of the constant to drift out of sync
+// (the bug class behind the original 0x10/0x20 inversion).
+inline CardEvent DetectCardStateChange(uint64_t oldState, uint64_t newState,
+                                       uint64_t presentMask) {
+    bool wasPresent = (oldState & presentMask) != 0;
+    bool isPresent = (newState & presentMask) != 0;
 
     if (!wasPresent && isPresent) return CardEvent::Inserted;
     if (wasPresent && !isPresent) return CardEvent::Removed;
     return CardEvent::None;
 }
+
+}  // namespace smartcard

--- a/src/test/reader_state_utils_test.cpp
+++ b/src/test/reader_state_utils_test.cpp
@@ -2,36 +2,54 @@
 #include "catch.hpp"
 #include "reader_state_utils.h"
 
-TEST_CASE("PCSC_STATE_PRESENT matches the PC/SC SCARD_STATE_PRESENT value", "[state]") {
-    // Pinned to the literal so a typo in the constant fails here instead of
-    // silently inverting every card event.
-    REQUIRE(PCSC_STATE_PRESENT == 0x00000020);
+using smartcard::CardEvent;
+using smartcard::DetectCardStateChange;
+
+// The production caller passes the platform's SCARD_STATE_PRESENT (0x20 on
+// Windows, macOS, and pcsc-lite); the helper itself is mask-agnostic, which
+// is what these tests exercise.
+namespace {
+constexpr uint64_t PRESENT = 0x00000020;
 }
 
 TEST_CASE("DetectCardStateChange", "[state]") {
     SECTION("returns Inserted when card becomes present") {
-        REQUIRE(DetectCardStateChange(0x00, 0x00000020) == CardEvent::Inserted);
+        REQUIRE(DetectCardStateChange(0x00, PRESENT, PRESENT) == CardEvent::Inserted);
     }
 
     SECTION("returns Removed when card becomes absent") {
-        REQUIRE(DetectCardStateChange(0x00000020, 0x00) == CardEvent::Removed);
+        REQUIRE(DetectCardStateChange(PRESENT, 0x00, PRESENT) == CardEvent::Removed);
     }
 
     SECTION("returns None when state unchanged - no card") {
-        REQUIRE(DetectCardStateChange(0x00, 0x00) == CardEvent::None);
+        REQUIRE(DetectCardStateChange(0x00, 0x00, PRESENT) == CardEvent::None);
     }
 
     SECTION("returns None when state unchanged - card present") {
-        REQUIRE(DetectCardStateChange(PCSC_STATE_PRESENT, PCSC_STATE_PRESENT) == CardEvent::None);
+        REQUIRE(DetectCardStateChange(PRESENT, PRESENT, PRESENT) == CardEvent::None);
     }
 
     SECTION("ignores other state flags on insertion") {
-        uint32_t OTHER_FLAGS = 0x00000102;
-        REQUIRE(DetectCardStateChange(OTHER_FLAGS, OTHER_FLAGS | PCSC_STATE_PRESENT) == CardEvent::Inserted);
+        uint64_t OTHER_FLAGS = 0x00000102;
+        REQUIRE(DetectCardStateChange(OTHER_FLAGS, OTHER_FLAGS | PRESENT, PRESENT) == CardEvent::Inserted);
     }
 
     SECTION("ignores other state flags on removal") {
-        uint32_t OTHER_FLAGS = 0x00000102;
-        REQUIRE(DetectCardStateChange(OTHER_FLAGS | PCSC_STATE_PRESENT, OTHER_FLAGS) == CardEvent::Removed);
+        uint64_t OTHER_FLAGS = 0x00000102;
+        REQUIRE(DetectCardStateChange(OTHER_FLAGS | PRESENT, OTHER_FLAGS, PRESENT) == CardEvent::Removed);
+    }
+
+    SECTION("only the given mask bit decides presence") {
+        // A transition on some other bit is not a card event
+        REQUIRE(DetectCardStateChange(0x00, 0x10, PRESENT) == CardEvent::None);
+        // The same transition IS a card event when that bit is the mask
+        REQUIRE(DetectCardStateChange(0x00, 0x10, 0x10) == CardEvent::Inserted);
+    }
+
+    SECTION("handles masks above 32 bits without truncation") {
+        // pcsc-lite's DWORD is 64-bit on Linux; a high bit must survive
+        uint64_t HIGH_BIT = 1ULL << 40;
+        REQUIRE(DetectCardStateChange(0x00, HIGH_BIT, HIGH_BIT) == CardEvent::Inserted);
+        REQUIRE(DetectCardStateChange(HIGH_BIT, 0x00, HIGH_BIT) == CardEvent::Removed);
     }
 }


### PR DESCRIPTION
## Summary

Root-cause fix for the deferred `reader_state_utils.h` findings. The helper used to mirror `SCARD_STATE_PRESENT` as a hand-typed constant so the header could stay PC/SC-free for the native test target — the exact duplication behind the original `0x10`/`0x20` event inversion, held in check since #131 by a `static_assert` and a pin test.

`DetectCardStateChange` now takes the mask as a parameter and the one production caller passes the platform macro directly. There is no copy of the value left to drift, so the assert and pin test are deleted rather than maintained — the bug class is unrepresentable instead of merely detected. Same injection pattern `devices.ts` has always used with `addon.SCARD_STATE_PRESENT`.

Also:

- **`namespace smartcard`** around the shipped header's three names — `PCSC_STATE_PRESENT` was styled like an SDK macro (one stray `#define` away from a compile error pointing at our header; `src/platform/pcsc.h` defines missing `SCARD_*` symbols in exactly that style), and `CardEvent` invited ODR collisions
- **`uint64_t` parameters** — pcsc-lite's `DWORD` is 64-bit on Linux, so the old `uint32_t` signature silently truncated at every Linux call site (benign today, `-Wconversion` bait forever)
- Tests now exercise the mask-agnostic logic properly, including a different-mask section and a >32-bit mask section

No behavior change; no consumer-visible API change (the header ships in the tarball but is only compiled as part of the addon).

## Testing

- Native suite: 10 assertions in 1 test case, all pass
- `npm test`: 121/121; build clean with 0 warnings; typecheck/lint clean
